### PR TITLE
fix(chart): remove SC from template

### DIFF
--- a/helm-charts/datacater/templates/postgres.yaml
+++ b/helm-charts/datacater/templates/postgres.yaml
@@ -93,7 +93,6 @@ spec:
         name: {{ .Values.postgres.pvc.volumeMountsName | default "postgres"}}
       spec:
         accessModes: [ "ReadWriteOnce" ]
-        storageClassName: {{ .Values.postgres.pvc.storageClassName | default "default"}}
         resources:
           requests:
             storage: 1Gi

--- a/helm-charts/datacater/templates/statefulset.yaml
+++ b/helm-charts/datacater/templates/statefulset.yaml
@@ -82,13 +82,3 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-  {{- if .Values.postgres.enabled }}
-  volumeClaimTemplates:
-    - metadata:
-        name: postgres
-      spec:
-        accessModes: [ "ReadWriteOnce" ]
-        resources:
-          requests:
-            storage: 1Gi
-  {{- end }}

--- a/k8s-manifests/minikube-with-postgres-ns-default.yaml
+++ b/k8s-manifests/minikube-with-postgres-ns-default.yaml
@@ -173,7 +173,6 @@ spec:
         name: postgres
       spec:
         accessModes: [ "ReadWriteOnce" ]
-        storageClassName: default
         resources:
           requests:
             storage: 1Gi

--- a/k8s-manifests/minikube-with-postgres-ns-default.yaml
+++ b/k8s-manifests/minikube-with-postgres-ns-default.yaml
@@ -261,11 +261,3 @@ spec:
             requests:
               cpu: 500m
               memory: 1Gi
-  volumeClaimTemplates:
-    - metadata:
-        name: postgres
-      spec:
-        accessModes: [ "ReadWriteOnce" ]
-        resources:
-          requests:
-            storage: 1Gi


### PR DESCRIPTION
Removing storage class from helm template
for postgres. This lets the underlying
distro use the actual default.