### PR TITLE
feat(ui): Warn about data type mismatches

### DIFF
--- a/ui/src/components/pipelines/PipelineDesigner.js
+++ b/ui/src/components/pipelines/PipelineDesigner.js
@@ -173,6 +173,7 @@ class PipelineDesigner extends Component {
                     handleChangeFunc={this.props.handleTransformStepChangeFunc}
                     hideContextBarFunc={this.props.hideContextBarFunc}
                     previewState={this.props.previewState}
+                    profile={this.props.profile}
                     transformStep={transformStep}
                     transforms={this.props.transforms}
                   />
@@ -185,6 +186,7 @@ class PipelineDesigner extends Component {
                     editColumn={this.props.editColumn}
                     filter={this.props.editColumn.filter}
                     filters={this.props.filters}
+                    profile={this.props.profile}
                     handleChangeFunc={this.props.handleFilterChangeFunc}
                     hideContextBarFunc={this.props.hideContextBarFunc}
                   />

--- a/ui/src/components/pipelines/pipeline_designer/Grid.js
+++ b/ui/src/components/pipelines/pipeline_designer/Grid.js
@@ -234,9 +234,10 @@ class Grid extends Component {
     let classNames = this.getClassNames(columns);
     const data = this.getData();
 
-    const gridTransformClassName = (this.props.currentPage === "transform")
-      ? " datacater-grid-container-transform"
-      : "";
+    const gridTransformClassName =
+      this.props.currentPage === "transform"
+        ? " datacater-grid-container-transform"
+        : "";
 
     return (
       <div className="container-fluid">

--- a/ui/src/components/pipelines/pipeline_designer/context_bar/filter/Attribute.js
+++ b/ui/src/components/pipelines/pipeline_designer/context_bar/filter/Attribute.js
@@ -1,11 +1,16 @@
 import React, { Component } from "react";
 import { Filter as FilterIcon, HelpCircle } from "react-feather";
 import { Button, OverlayTrigger, Tooltip } from "react-bootstrap";
+import DataTypeIcon from "../../grid/DataTypeIcon";
 import AttributeFilterList from "./AttributeFilterList";
 
 class Attribute extends Component {
   render() {
-    const { attribute, filter, filters, handleChangeFunc } = this.props;
+    const { attribute, filter, filters, handleChangeFunc, profile } =
+      this.props;
+
+    const attributeProfile = profile[attribute];
+    const attributeDataType = attributeProfile.dataType;
 
     const currentFilter =
       filter.filter === ""
@@ -19,18 +24,29 @@ class Attribute extends Component {
         ? filter.filterConfig
         : {};
 
+    const filterExpectsDataType =
+      currentFilter !== undefined &&
+      currentFilter.labels !== undefined &&
+      currentFilter.labels["input-types"] !== undefined
+        ? currentFilter.labels["input-types"].includes(attributeDataType)
+        : true;
+
     return (
       <React.Fragment>
         <div className="row border-bottom py-4">
           <div className="col ps-0">
-            <h3 className="fw-bold mb-0 text-nowrap">{attribute}</h3>
+            <h3 className="mb-0 overflow-hidden text-nowrap d-flex align-items-center">
+              <DataTypeIcon dataType={attributeProfile.dataType} />{" "}
+              <span className="ms-1">{attribute}</span>
+            </h3>
           </div>
         </div>
 
         {!filterIsDefined && (
           <AttributeFilterList
-            filter={filter}
             attribute={attribute}
+            attributeDataType={attributeProfile.dataType}
+            filter={filter}
             filters={filters}
             handleChangeFunc={handleChangeFunc}
           />
@@ -67,6 +83,12 @@ class Attribute extends Component {
               </div>
             </div>
             <div className="form-group mb-0 py-4 datacater-context-bar-function-config">
+              {!filterExpectsDataType && (
+                <div className="alert alert-warning">
+                  The filter <i>{filter.key}</i> does not support the input type{" "}
+                  <i>{attributeDataType}</i>.
+                </div>
+              )}
               {currentFilter &&
                 currentFilter.config &&
                 currentFilter.config.map((configOption, idx) => (

--- a/ui/src/components/pipelines/pipeline_designer/context_bar/filter/AttributeFilterList.js
+++ b/ui/src/components/pipelines/pipeline_designer/context_bar/filter/AttributeFilterList.js
@@ -21,17 +21,12 @@ class AttributeFilterList extends Component {
   }
 
   render() {
-    const { filter, attribute } = this.props;
+    const { filter, attribute, attributeDataType } = this.props;
 
     const searchTokens = this.state.searchQuery.toLowerCase().trim().split(" ");
     const filtersItems = deepCopy(this.props.filters);
 
     const filters = filtersItems
-      .filter(
-        (filter) =>
-          filter.restrictToDataType === undefined ||
-          filter.restrictToDataType.includes(attribute.dataType)
-      )
       .filter(
         (filter) =>
           searchTokens
@@ -61,7 +56,7 @@ class AttributeFilterList extends Component {
           <div className="datacater-popover-pipeline-filter-list pt-2 list-group-flush list mx-n4 datacater-context-bar-flex-list">
             {filters.map((f, index) => (
               <ListGroup.Item
-                className="px-3 pt-3 pb-0 border-0 font-size-sm"
+                className="px-4 pt-3 pb-0 border-0 font-size-sm"
                 key={index}
                 action
                 onClick={(event) => {

--- a/ui/src/components/pipelines/pipeline_designer/context_bar/filter/Edit.js
+++ b/ui/src/components/pipelines/pipeline_designer/context_bar/filter/Edit.js
@@ -12,6 +12,7 @@ class Edit extends Component {
           attribute={this.props.attribute}
           editColumn={this.props.editColumn}
           handleChangeFunc={this.props.handleChangeFunc}
+          profile={this.props.profile}
         />
 
         <div className="datacater-context-bar-button-group border-top d-flex align-items-center bg-white mx-n4 px-4 datacater-context-bar-fixed-element">

--- a/ui/src/components/pipelines/pipeline_designer/context_bar/transformation/Attribute.js
+++ b/ui/src/components/pipelines/pipeline_designer/context_bar/transformation/Attribute.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import { humanizeDataType } from "../../../../../helpers/humanizeDataType";
 import AttributeTransformationList from "./AttributeTransformationList";
+import DataTypeIcon from "../../grid/DataTypeIcon";
 import Config from "./Config";
 
 class Attribute extends Component {
@@ -11,6 +12,7 @@ class Attribute extends Component {
       editColumn,
       filters,
       handleChangeFunc,
+      profile,
       sortPosition,
       transformStep,
       transforms,
@@ -19,6 +21,8 @@ class Attribute extends Component {
     const attribute = attributes.find(
       (attr) => attr === editColumn.attributeName
     );
+
+    const attributeProfile = profile[attribute];
 
     const pipelineAttribute = transformStep.transformations.find(
       (transform) => transform.attributeName === attribute
@@ -39,12 +43,16 @@ class Attribute extends Component {
       <React.Fragment>
         <div className="row border-bottom py-4">
           <div className="col ps-0">
-            <h3 className="mb-0 text-nowrap">{attribute}</h3>
+            <h3 className="mb-0 overflow-hidden text-nowrap d-flex align-items-center">
+              <DataTypeIcon dataType={attributeProfile.dataType} />{" "}
+              <span className="ms-1">{attribute}</span>
+            </h3>
           </div>
         </div>
         {transform == null && (
           <AttributeTransformationList
             attribute={attribute}
+            attributeDataType={attributeProfile.dataType}
             currentStep={currentStep}
             handleChangeFunc={handleChangeFunc}
             transformStep={transformStep}
@@ -55,6 +63,7 @@ class Attribute extends Component {
           <Config
             attribute={attribute}
             attributes={attributes}
+            attributeDataType={attributeProfile.dataType}
             currentStep={currentStep}
             editColumn={editColumn}
             filter={filter}

--- a/ui/src/components/pipelines/pipeline_designer/context_bar/transformation/AttributeTransformationList.js
+++ b/ui/src/components/pipelines/pipeline_designer/context_bar/transformation/AttributeTransformationList.js
@@ -20,6 +20,7 @@ class AttributeTransformationList extends Component {
   render() {
     const {
       attribute,
+      attributeDataType,
       currentStep,
       handleChangeFunc,
       transformStep,
@@ -31,12 +32,12 @@ class AttributeTransformationList extends Component {
       // Do not allow to apply the "Add column" transform to another attribute
       .filter((transform) => transform.key !== "add-column")
       .filter(
-        (transformer) =>
+        (transform) =>
           searchTokens
             .map(
               (token) =>
-                transformer.name.toLowerCase().includes(token) ||
-                transformer.description.toLowerCase().includes(token)
+                transform.name.toLowerCase().includes(token) ||
+                transform.description.toLowerCase().includes(token)
             )
             .filter((_) => _).length === searchTokens.length
       )
@@ -59,7 +60,7 @@ class AttributeTransformationList extends Component {
           <div className="datacater-popover-pipeline-filter-list pt-2 list-group-flush list mx-n4 datacater-context-bar-flex-list">
             {transformers.map((transform, index) => (
               <ListGroup.Item
-                className="px-3 pt-3 pb-0 border-0 font-size-sm"
+                className="px-4 pt-3 pb-0 border-0 font-size-sm"
                 key={index}
                 action
                 onClick={(event) => {

--- a/ui/src/components/pipelines/pipeline_designer/context_bar/transformation/Config.js
+++ b/ui/src/components/pipelines/pipeline_designer/context_bar/transformation/Config.js
@@ -9,6 +9,7 @@ class Config extends Component {
     const {
       attribute,
       attributes,
+      attributeDataType,
       currentStep,
       editColumn,
       filter,
@@ -28,10 +29,24 @@ class Config extends Component {
         ? pipelineAttribute.transformationConfig
         : {};
 
+    const transformExpectsDataType =
+      transform !== undefined &&
+      transform.labels !== undefined &&
+      transform.labels["input-types"] !== undefined
+        ? transform.labels["input-types"].includes(attributeDataType)
+        : true;
+
     const filterConfig =
       pipelineAttribute !== undefined && pipelineAttribute.filterConfig != null
         ? pipelineAttribute.filterConfig
         : {};
+
+    const filterExpectsDataType =
+      filter !== undefined &&
+      filter.labels !== undefined &&
+      filter.labels["input-types"] !== undefined
+        ? filter.labels["input-types"].includes(attributeDataType)
+        : true;
 
     /*
     if (transform !== undefined && transformer.key === "add-column") {
@@ -80,6 +95,12 @@ class Config extends Component {
           </div>
         </div>
         <div className="form-group mb-0 py-4 datacater-context-bar-function-config">
+          {!transformExpectsDataType && (
+            <div className="alert alert-warning">
+              The transform <i>{transform.key}</i> does not support the input
+              type <i>{attributeDataType}</i>.
+            </div>
+          )}
           {transform.config !== undefined &&
             transform.config.map((configOption, idx) => (
               <div key={idx}>
@@ -152,6 +173,12 @@ class Config extends Component {
                 ))}
               </React.Fragment>
             </select>
+            {!filterExpectsDataType && (
+              <div className="alert alert-warning mt-4 mb-0">
+                The filter <i>{filter.key}</i> does not support the input type{" "}
+                <i>{attributeDataType}</i>.
+              </div>
+            )}
             {filter &&
               filter.config &&
               filter.config.map((configOption, idx) => (

--- a/ui/src/components/pipelines/pipeline_designer/context_bar/transformation/Edit.js
+++ b/ui/src/components/pipelines/pipeline_designer/context_bar/transformation/Edit.js
@@ -14,6 +14,7 @@ class Edit extends Component {
           filters={this.props.filters}
           handleChangeFunc={this.props.handleChangeFunc}
           previewState={this.props.previewState}
+          profile={this.props.profile}
           transformStep={this.props.transformStep}
           transforms={this.props.transforms}
         />

--- a/ui/src/components/pipelines/pipeline_designer/grid/DataTypeIcon.js
+++ b/ui/src/components/pipelines/pipeline_designer/grid/DataTypeIcon.js
@@ -1,0 +1,53 @@
+import React, { Component } from "react";
+import { Button, Modal } from "react-bootstrap";
+import { Check, Code, Hash, HelpCircle, List, Type } from "react-feather";
+
+class DataTypeIcon extends Component {
+  render() {
+    let dataTypeIcon = <HelpCircle className="feather-icon" />;
+
+    switch (this.props.dataType) {
+      case "array":
+        dataTypeIcon = (
+          <span title="Array">
+            <List className="feather-icon" />
+          </span>
+        );
+        break;
+      case "object":
+        dataTypeIcon = (
+          <span title="Object">
+            <Code className="feather-icon" />
+          </span>
+        );
+        break;
+      case "boolean":
+        dataTypeIcon = (
+          <span title="Boolean">
+            <Check className="feather-icon" />
+          </span>
+        );
+        break;
+      case "number":
+        dataTypeIcon = (
+          <span title="Number">
+            <Hash className="feather-icon" />
+          </span>
+        );
+        break;
+      case "string":
+        dataTypeIcon = (
+          <span title="String">
+            <Type className="feather-icon" />
+          </span>
+        );
+        break;
+      default:
+        break;
+    }
+
+    return dataTypeIcon;
+  }
+}
+
+export default DataTypeIcon;

--- a/ui/src/components/pipelines/pipeline_designer/grid/TableHeaderCell.js
+++ b/ui/src/components/pipelines/pipeline_designer/grid/TableHeaderCell.js
@@ -1,18 +1,7 @@
 import React, { Component } from "react";
 import { Button, Modal } from "react-bootstrap";
-import {
-  ArrowRight,
-  Check,
-  Code,
-  Filter,
-  Hash,
-  HelpCircle,
-  Key,
-  List,
-  Package,
-  Trash,
-  Type,
-} from "react-feather";
+import { ArrowRight, Code, Filter, Key, Package, Trash } from "react-feather";
+import DataTypeIcon from "./DataTypeIcon";
 import FrequentValues from "../../../data_profiler/FrequentValues";
 import AttributeStats from "../../../data_profiler/AttributeStats";
 import "../../../../scss/grid/statistics.scss";
@@ -26,59 +15,17 @@ class TableHeaderCell extends Component {
   }
 
   renderAttributeName(attribute) {
-    let dataTypeIcon = <HelpCircle className="feather-icon" />;
-
-    switch (attribute.dataType) {
-      case "array":
-        dataTypeIcon = (
-          <span title="Array">
-            <List className="feather-icon" />
-          </span>
-        );
-        break;
-      case "object":
-        dataTypeIcon = (
-          <span title="Object">
-            <Code className="feather-icon" />
-          </span>
-        );
-        break;
-      case "boolean":
-        dataTypeIcon = (
-          <span title="Boolean">
-            <Check className="feather-icon" />
-          </span>
-        );
-        break;
-      case "number":
-        dataTypeIcon = (
-          <span title="Number">
-            <Hash className="feather-icon" />
-          </span>
-        );
-        break;
-      case "string":
-        dataTypeIcon = (
-          <span title="String">
-            <Type className="feather-icon" />
-          </span>
-        );
-        break;
-      default:
-        break;
-    }
-
     if (attribute.oldName === undefined) {
       return (
         <div className="d-flex align-items-center">
           {[undefined, ""].includes(attribute.name) && (
             <span className="font-italic">
-              {dataTypeIcon} Untitled attribute
+              <DataTypeIcon dataType={attribute.dataType} /> Untitled attribute
             </span>
           )}
           {![undefined, ""].includes(attribute.name) && (
             <span>
-              {dataTypeIcon} {attribute.name}
+              <DataTypeIcon dataType={attribute.dataType} /> {attribute.name}
             </span>
           )}
         </div>

--- a/ui/src/scss/context-bar.scss
+++ b/ui/src/scss/context-bar.scss
@@ -26,7 +26,6 @@
   &-function-config {
     height: calc(100vh - 17rem);
     overflow-x: hidden;
-    overflow-y: scroll;
   }
 
   &-flex-list {


### PR DESCRIPTION
When adding a transform or filter to a field in the UI, warn the user if the filter or transform expects another data type than the one of the field.

Example:

![Screenshot 2022-10-13 at 09 45 10](https://user-images.githubusercontent.com/128683/195534264-34a1263f-8b6a-47da-a32e-c431db06ded3.png)
