### PR TITLE
Feat(pipeline): create initial pipeline implementation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,4 +154,3 @@ For testing and development you can find self-signed certificates under
 ```bash
  openssl req -nodes -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 365 -subj '/CN=localhost'
 ```
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,5 +144,14 @@ ct lint --all --config helm-charts/ct.yaml
 # Install the chart and run tests if available
 ct install --namespace default --all --config helm-charts/ct.yaml
 ```
-
 See https://github.com/helm/chart-testing#usage for details
+
+### How do I update the self-signed certificates?
+
+For testing and development you can find self-signed certificates under
+`platform-api/src/main/resources/`. To update these run ...
+
+```bash
+ openssl req -nodes -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 365 -subj '/CN=localhost'
+```
+

--- a/licenses/platform-api/third_party.md
+++ b/licenses/platform-api/third_party.md
@@ -2,10 +2,10 @@
 
 | Dependency              | Version      | License                                                   |
 |:------------------------|:-------------|:----------------------------------------------------------|
-| Quarkus                 | 2.12.0.Final | [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) | 
-| Quarkus Hibernate Types | 0.2.0        | [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) | 
-| Kafka Clients           | 3.2.0        | [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) | 
-| Rest Assured            | 5.2.0        | [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) | 
+| Quarkus                 | 2.12.0.Final | [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
+| Quarkus Hibernate Types | 0.2.0        | [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
+| Kafka Clients           | 3.2.0        | [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
+| Rest Assured            | 5.2.0        | [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 
 
 NOTE: All Quarkus Extensions are under the Apache-2 license as stated in their FAQ and on GitHub:

--- a/licenses/serde/third_party.md
+++ b/licenses/serde/third_party.md
@@ -2,9 +2,9 @@
 
 | Dependency            | Version      | License                                                   |
 |:----------------------|:-------------|:----------------------------------------------------------|
-| Quarkus               | 2.12.0.Final | [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) | 
-| Avro                  | 1.11.1       | [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) | 
-| Kafka Avro Serializer | 7.2.1        | [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) | 
+| Quarkus               | 2.12.0.Final | [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
+| Avro                  | 1.11.1       | [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
+| Kafka Avro Serializer | 7.2.1        | [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 
 
 NOTE: All Quarkus Extensions are under the Apache-2 license as stated in their FAQ and on GitHub:

--- a/pipeline/build.gradle
+++ b/pipeline/build.gradle
@@ -1,0 +1,66 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+    id 'com.diffplug.spotless' version '6.8.0'
+}
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+    maven {
+        url 'https://packages.confluent.io/maven/'
+        content {
+            includeGroup 'io.confluent'
+        }
+    }
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    // quarkus core
+    implementation 'io.quarkus:quarkus-config-yaml'
+    implementation 'io.quarkus:quarkus-logging-json'
+    implementation 'io.quarkus:quarkus-arc'
+
+    implementation 'io.quarkus:quarkus-smallrye-openapi'
+
+    // smallrye reactive messaging
+    implementation 'io.quarkus:quarkus-smallrye-reactive-messaging'
+    implementation 'io.quarkus:quarkus-smallrye-reactive-messaging-kafka'
+
+    implementation 'io.quarkus:quarkus-resteasy-reactive-jackson'
+    implementation 'io.quarkus:quarkus-vertx'
+    implementation 'io.smallrye.reactive:smallrye-mutiny-vertx-web-client'
+    implementation 'io.quarkus:quarkus-resteasy-reactive'
+
+    //datacater SerDe
+    implementation project(':serde')
+
+    //devservice dependency for customer serde
+    implementation 'io.quarkus:quarkus-confluent-registry-avro'
+
+    // Build images at compile and runtime
+    implementation 'io.quarkus:quarkus-container-image-jib'
+
+    testImplementation 'io.quarkus:quarkus-junit5'
+    testImplementation 'io.quarkus:quarkus-test-kafka-companion'
+
+    implementation 'org.testcontainers:testcontainers:1.17.3'
+}
+
+group 'io.datacater'
+version 'alpha'
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
+}
+
+compileTestJava {
+    options.encoding = 'UTF-8'
+}

--- a/pipeline/src/main/docker/Dockerfile.jvm
+++ b/pipeline/src/main/docker/Dockerfile.jvm
@@ -1,0 +1,93 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in JVM mode
+#
+# Before building the container image run:
+#
+# ./gradlew build
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/pipeline-jvm .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/pipeline-jvm
+#
+# If you want to include the debug port into your docker image
+# you will have to expose the debug port (default 5005) like this :  EXPOSE 8080 5005
+#
+# Then run the container using :
+#
+# docker run -i --rm -p 8080:8080 quarkus/pipeline-jvm
+#
+# This image uses the `run-java.sh` script to run the application.
+# This scripts computes the command line to execute your Java application, and
+# includes memory/GC tuning.
+# You can configure the behavior using the following environment properties:
+# - JAVA_OPTS: JVM options passed to the `java` command (example: "-verbose:class")
+# - JAVA_OPTS_APPEND: User specified Java options to be appended to generated options
+#   in JAVA_OPTS (example: "-Dsome.property=foo")
+# - JAVA_MAX_MEM_RATIO: Is used when no `-Xmx` option is given in JAVA_OPTS. This is
+#   used to calculate a default maximal heap memory based on a containers restriction.
+#   If used in a container without any memory constraints for the container then this
+#   option has no effect. If there is a memory constraint then `-Xmx` is set to a ratio
+#   of the container available memory as set here. The default is `50` which means 50%
+#   of the available memory is used as an upper boundary. You can skip this mechanism by
+#   setting this value to `0` in which case no `-Xmx` option is added.
+# - JAVA_INITIAL_MEM_RATIO: Is used when no `-Xms` option is given in JAVA_OPTS. This
+#   is used to calculate a default initial heap memory based on the maximum heap memory.
+#   If used in a container without any memory constraints for the container then this
+#   option has no effect. If there is a memory constraint then `-Xms` is set to a ratio
+#   of the `-Xmx` memory as set here. The default is `25` which means 25% of the `-Xmx`
+#   is used as the initial heap size. You can skip this mechanism by setting this value
+#   to `0` in which case no `-Xms` option is added (example: "25")
+# - JAVA_MAX_INITIAL_MEM: Is used when no `-Xms` option is given in JAVA_OPTS.
+#   This is used to calculate the maximum value of the initial heap memory. If used in
+#   a container without any memory constraints for the container then this option has
+#   no effect. If there is a memory constraint then `-Xms` is limited to the value set
+#   here. The default is 4096MB which means the calculated value of `-Xms` never will
+#   be greater than 4096MB. The value of this variable is expressed in MB (example: "4096")
+# - JAVA_DIAGNOSTICS: Set this to get some diagnostics information to standard output
+#   when things are happening. This option, if set to true, will set
+#  `-XX:+UnlockDiagnosticVMOptions`. Disabled by default (example: "true").
+# - JAVA_DEBUG: If set remote debugging will be switched on. Disabled by default (example:
+#    true").
+# - JAVA_DEBUG_PORT: Port used for remote debugging. Defaults to 5005 (example: "8787").
+# - CONTAINER_CORE_LIMIT: A calculated core limit as described in
+#   https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt. (example: "2")
+# - CONTAINER_MAX_MEMORY: Memory limit given to the container (example: "1024").
+# - GC_MIN_HEAP_FREE_RATIO: Minimum percentage of heap free after GC to avoid expansion.
+#   (example: "20")
+# - GC_MAX_HEAP_FREE_RATIO: Maximum percentage of heap free after GC to avoid shrinking.
+#   (example: "40")
+# - GC_TIME_RATIO: Specifies the ratio of the time spent outside the garbage collection.
+#   (example: "4")
+# - GC_ADAPTIVE_SIZE_POLICY_WEIGHT: The weighting given to the current GC time versus
+#   previous GC times. (example: "90")
+# - GC_METASPACE_SIZE: The initial metaspace size. (example: "20")
+# - GC_MAX_METASPACE_SIZE: The maximum metaspace size. (example: "100")
+# - GC_CONTAINER_OPTIONS: Specify Java GC to use. The value of this variable should
+#   contain the necessary JRE command-line options to specify the required GC, which
+#   will override the default of `-XX:+UseParallelGC` (example: -XX:+UseG1GC).
+# - HTTPS_PROXY: The location of the https proxy. (example: "myuser@127.0.0.1:8080")
+# - HTTP_PROXY: The location of the http proxy. (example: "myuser@127.0.0.1:8080")
+# - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
+#   accessed directly. (example: "foo.example.com,bar.example.com")
+#
+###
+FROM registry.access.redhat.com/ubi8/openjdk-11:1.11
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+
+# We make four distinct layers so if there are application changes the library layers can be re-used
+COPY --chown=185 build/quarkus-app/lib/ /deployments/lib/
+COPY --chown=185 build/quarkus-app/*.jar /deployments/
+COPY --chown=185 build/quarkus-app/app/ /deployments/app/
+COPY --chown=185 build/quarkus-app/quarkus/ /deployments/quarkus/
+
+EXPOSE 8080
+USER 185
+ENV AB_JOLOKIA_OFF=""
+ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/pipeline/src/main/docker/Dockerfile.legacy-jar
+++ b/pipeline/src/main/docker/Dockerfile.legacy-jar
@@ -1,0 +1,90 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in JVM mode
+#
+# Before building the container image run:
+#
+# ./gradlew build -Dquarkus.package.type=legacy-jar
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.legacy-jar -t quarkus/pipeline-legacy-jar .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/pipeline-legacy-jar
+#
+# If you want to include the debug port into your docker image
+# you will have to expose the debug port (default 5005) like this :  EXPOSE 8080 5005
+#
+# Then run the container using :
+#
+# docker run -i --rm -p 8080:8080 quarkus/pipeline-legacy-jar
+#
+# This image uses the `run-java.sh` script to run the application.
+# This scripts computes the command line to execute your Java application, and
+# includes memory/GC tuning.
+# You can configure the behavior using the following environment properties:
+# - JAVA_OPTS: JVM options passed to the `java` command (example: "-verbose:class")
+# - JAVA_OPTS_APPEND: User specified Java options to be appended to generated options
+#   in JAVA_OPTS (example: "-Dsome.property=foo")
+# - JAVA_MAX_MEM_RATIO: Is used when no `-Xmx` option is given in JAVA_OPTS. This is
+#   used to calculate a default maximal heap memory based on a containers restriction.
+#   If used in a container without any memory constraints for the container then this
+#   option has no effect. If there is a memory constraint then `-Xmx` is set to a ratio
+#   of the container available memory as set here. The default is `50` which means 50%
+#   of the available memory is used as an upper boundary. You can skip this mechanism by
+#   setting this value to `0` in which case no `-Xmx` option is added.
+# - JAVA_INITIAL_MEM_RATIO: Is used when no `-Xms` option is given in JAVA_OPTS. This
+#   is used to calculate a default initial heap memory based on the maximum heap memory.
+#   If used in a container without any memory constraints for the container then this
+#   option has no effect. If there is a memory constraint then `-Xms` is set to a ratio
+#   of the `-Xmx` memory as set here. The default is `25` which means 25% of the `-Xmx`
+#   is used as the initial heap size. You can skip this mechanism by setting this value
+#   to `0` in which case no `-Xms` option is added (example: "25")
+# - JAVA_MAX_INITIAL_MEM: Is used when no `-Xms` option is given in JAVA_OPTS.
+#   This is used to calculate the maximum value of the initial heap memory. If used in
+#   a container without any memory constraints for the container then this option has
+#   no effect. If there is a memory constraint then `-Xms` is limited to the value set
+#   here. The default is 4096MB which means the calculated value of `-Xms` never will
+#   be greater than 4096MB. The value of this variable is expressed in MB (example: "4096")
+# - JAVA_DIAGNOSTICS: Set this to get some diagnostics information to standard output
+#   when things are happening. This option, if set to true, will set
+#  `-XX:+UnlockDiagnosticVMOptions`. Disabled by default (example: "true").
+# - JAVA_DEBUG: If set remote debugging will be switched on. Disabled by default (example:
+#    true").
+# - JAVA_DEBUG_PORT: Port used for remote debugging. Defaults to 5005 (example: "8787").
+# - CONTAINER_CORE_LIMIT: A calculated core limit as described in
+#   https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt. (example: "2")
+# - CONTAINER_MAX_MEMORY: Memory limit given to the container (example: "1024").
+# - GC_MIN_HEAP_FREE_RATIO: Minimum percentage of heap free after GC to avoid expansion.
+#   (example: "20")
+# - GC_MAX_HEAP_FREE_RATIO: Maximum percentage of heap free after GC to avoid shrinking.
+#   (example: "40")
+# - GC_TIME_RATIO: Specifies the ratio of the time spent outside the garbage collection.
+#   (example: "4")
+# - GC_ADAPTIVE_SIZE_POLICY_WEIGHT: The weighting given to the current GC time versus
+#   previous GC times. (example: "90")
+# - GC_METASPACE_SIZE: The initial metaspace size. (example: "20")
+# - GC_MAX_METASPACE_SIZE: The maximum metaspace size. (example: "100")
+# - GC_CONTAINER_OPTIONS: Specify Java GC to use. The value of this variable should
+#   contain the necessary JRE command-line options to specify the required GC, which
+#   will override the default of `-XX:+UseParallelGC` (example: -XX:+UseG1GC).
+# - HTTPS_PROXY: The location of the https proxy. (example: "myuser@127.0.0.1:8080")
+# - HTTP_PROXY: The location of the http proxy. (example: "myuser@127.0.0.1:8080")
+# - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
+#   accessed directly. (example: "foo.example.com,bar.example.com")
+#
+###
+FROM registry.access.redhat.com/ubi8/openjdk-11:1.11
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+
+COPY build/lib/* /deployments/lib/
+COPY build/*-runner.jar /deployments/quarkus-run.jar
+
+EXPOSE 8080
+USER 185
+ENV AB_JOLOKIA_OFF=""
+ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/pipeline/src/main/docker/Dockerfile.native
+++ b/pipeline/src/main/docker/Dockerfile.native
@@ -1,0 +1,27 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in native (no JVM) mode.
+#
+# Before building the container image run:
+#
+# ./gradlew build -Dquarkus.package.type=native
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.native -t quarkus/pipeline .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/pipeline
+#
+###
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
+WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+COPY --chown=1001:root build/*-runner /work/application
+
+EXPOSE 8080
+USER 1001
+
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/pipeline/src/main/docker/Dockerfile.native-micro
+++ b/pipeline/src/main/docker/Dockerfile.native-micro
@@ -1,0 +1,30 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in native (no JVM) mode.
+# It uses a micro base image, tuned for Quarkus native executables.
+# It reduces the size of the resulting container image.
+# Check https://quarkus.io/guides/quarkus-runtime-base-image for further information about this image.
+#
+# Before building the container image run:
+#
+# ./gradlew build -Dquarkus.package.type=native
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.native-micro -t quarkus/pipeline .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/pipeline
+#
+###
+FROM quay.io/quarkus/quarkus-micro-image:1.0
+WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+COPY --chown=1001:root build/*-runner /work/application
+
+EXPOSE 8080
+USER 1001
+
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/pipeline/src/main/java/io/datacater/Pipeline.java
+++ b/pipeline/src/main/java/io/datacater/Pipeline.java
@@ -1,0 +1,93 @@
+package io.datacater;
+
+import io.datacater.exceptions.TransformationException;
+import io.smallrye.common.annotation.Blocking;
+import io.vertx.core.json.JsonObject;
+import io.smallrye.reactive.messaging.kafka.Record;
+
+import java.util.UUID;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.core.buffer.Buffer;
+import io.vertx.mutiny.ext.web.client.HttpRequest;
+import io.vertx.mutiny.ext.web.client.HttpResponse;
+import io.vertx.mutiny.ext.web.client.WebClient;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.RestResponse;
+
+@ApplicationScoped
+public class Pipeline {
+  private static final Logger LOGGER = Logger.getLogger(Pipeline.class);
+
+  private final Integer DATACATER_PYTHONRUNNER_PORT =
+          ConfigProvider.getConfig()
+                  .getOptionalValue("datacater.python-runner.port", Integer.class)
+                  .orElse(50000);
+
+  private final String DATACATER_PYTHONRUNNER_HOST =
+          ConfigProvider.getConfig()
+                  .getOptionalValue("datacater.python-runner.host", String.class)
+                  .orElse("localhost");
+
+  private String host;
+  private Integer port;
+
+  private static final String PIPELINE_IN = "pipeline-in";
+  private static final String PIPELINE_OUT = "pipeline-out";
+  private static final String PIPELINE_ERROR_MSG = "Pipeline could not process message.\n Key: %s\n Value: %s";
+
+  WebClient client;
+
+  @Inject
+  void VertxResource(Vertx vertx) {
+    this.client = WebClient.create(vertx);
+  }
+
+  @Incoming(PIPELINE_IN)
+  @Outgoing(PIPELINE_OUT)
+  @Blocking
+  @Acknowledgment(Acknowledgment.Strategy.POST_PROCESSING)
+  public Record<UUID, JsonObject> processUUID(Record<UUID, JsonObject> message) {
+    // This is deliberately blocking
+    JsonObject transformedMessage = handleMessage(message);
+    return Record.of(message.key(), transformedMessage);
+  }
+
+  private JsonObject handleMessage(Record<UUID, JsonObject> message) {
+    HttpRequest<Buffer> request = client.post(getPort(), getHost(), "");
+    HttpResponse<Buffer> response = request.sendJson(message.value().encode()).await().indefinitely();
+
+    if(response.statusCode() != RestResponse.StatusCode.OK){
+      String errorMsg = String.format(PIPELINE_ERROR_MSG, message.key(), response.bodyAsJsonObject().encodePrettily());
+      LOGGER.error(errorMsg);
+      throw new TransformationException(errorMsg);
+    }
+
+    return response.bodyAsJsonObject().getJsonObject("value");
+  }
+
+  protected void setNetwork(int port, String host){
+    this.host = host;
+    this.port = port;
+  }
+
+  private String getHost(){
+    if(host != null){
+      return host;
+    }
+    return DATACATER_PYTHONRUNNER_HOST;
+  }
+
+  private int getPort(){
+    if (port != null){
+      return port;
+    }
+    return DATACATER_PYTHONRUNNER_PORT;
+  }
+}

--- a/pipeline/src/main/java/io/datacater/Pipeline.java
+++ b/pipeline/src/main/java/io/datacater/Pipeline.java
@@ -65,14 +65,13 @@ public class Pipeline {
             .putHeader("Content-Type", "application/json");
     HttpResponse<Buffer> response = request.sendJson(new JsonArray().add(getMessage(message))).await().indefinitely();
 
-    LOGGER.info(response.statusCode());
     if(response.statusCode() != RestResponse.StatusCode.OK){
-      String errorMsg = String.format(PIPELINE_ERROR_MSG, message.key(), response.bodyAsJsonObject().encodePrettily());
+      String errorMsg = String.format(PIPELINE_ERROR_MSG, message.key(), response.bodyAsJsonArray().encodePrettily());
       LOGGER.error(errorMsg);
       throw new TransformationException(errorMsg);
     }
 
-    return response.bodyAsJsonObject().getJsonObject("value");
+    return response.bodyAsJsonArray().getJsonObject(0).getJsonObject("value");
   }
 
   protected void setNetwork(int port, String host){

--- a/pipeline/src/main/java/io/datacater/Pipeline.java
+++ b/pipeline/src/main/java/io/datacater/Pipeline.java
@@ -63,7 +63,6 @@ public class Pipeline {
   private JsonObject handleMessage(Record<UUID, JsonObject> message) {
     HttpRequest<Buffer> request = client.post(getPort(), getHost(), "/batch")
             .putHeader("Content-Type", "application/json");
-    LOGGER.info(new JsonArray().add(getMessage(message)));
     HttpResponse<Buffer> response = request.sendJson(new JsonArray().add(getMessage(message))).await().indefinitely();
 
     LOGGER.info(response.statusCode());

--- a/pipeline/src/main/java/io/datacater/Pipeline.java
+++ b/pipeline/src/main/java/io/datacater/Pipeline.java
@@ -39,8 +39,8 @@ public class Pipeline {
   private String host;
   private Integer port;
 
-  private static final String PIPELINE_IN = "pipeline-in";
-  private static final String PIPELINE_OUT = "pipeline-out";
+  private static final String STREAM_IN = "stream-in";
+  private static final String STREAM_OUT = "stream-out";
   private static final String PIPELINE_ERROR_MSG = "Pipeline could not process message.\n Key: %s\n Value: %s";
 
   WebClient client;
@@ -50,8 +50,8 @@ public class Pipeline {
     this.client = WebClient.create(vertx);
   }
 
-  @Incoming(PIPELINE_IN)
-  @Outgoing(PIPELINE_OUT)
+  @Incoming(STREAM_IN)
+  @Outgoing(STREAM_OUT)
   @Blocking
   @Acknowledgment(Acknowledgment.Strategy.POST_PROCESSING)
   public Record<UUID, JsonObject> processUUID(Record<UUID, JsonObject> message) {

--- a/pipeline/src/main/java/io/datacater/Pipeline.java
+++ b/pipeline/src/main/java/io/datacater/Pipeline.java
@@ -6,6 +6,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.smallrye.reactive.messaging.kafka.Record;
 
+import java.time.Duration;
 import java.util.UUID;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -49,7 +50,7 @@ public class Pipeline {
   private void handleMessages(ConsumerRecords<JsonObject, JsonObject> messages) {
     HttpRequest<Buffer> request = client.post(getPort(), getHost(), PipelineConfig.ENDPOINT)
             .putHeader(PipelineConfig.HEADER, PipelineConfig.HEADER_TYPE);
-    HttpResponse<Buffer> response = request.sendJson(getMessages(messages)).await().indefinitely();
+    HttpResponse<Buffer> response = request.sendJson(getMessages(messages)).await().atMost(Duration.ofSeconds(PipelineConfig.DATACATER_PYTHONRUNNER_TIMEOUT));
 
     if(response.statusCode() != RestResponse.StatusCode.OK){
       LOGGER.error(response.bodyAsJsonObject().encodePrettily());

--- a/pipeline/src/main/java/io/datacater/PipelineConfig.java
+++ b/pipeline/src/main/java/io/datacater/PipelineConfig.java
@@ -19,6 +19,11 @@ public class PipelineConfig {
                     .getOptionalValue("datacater.python-runner.host", String.class)
                     .orElse("localhost");
 
+    static final Integer DATACATER_PYTHONRUNNER_TIMEOUT =
+            ConfigProvider.getConfig()
+                    .getOptionalValue("datacater.python-runner.timeout", Integer.class)
+                    .orElse(60);
+
     static final String STREAM_IN = "stream-in";
     static final String STREAM_OUT = "stream-out";
     static final String ENDPOINT = "/batch";

--- a/pipeline/src/main/java/io/datacater/PipelineConfig.java
+++ b/pipeline/src/main/java/io/datacater/PipelineConfig.java
@@ -1,0 +1,34 @@
+package io.datacater;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class PipelineConfig {
+
+    private PipelineConfig() {}
+
+    static final Integer DATACATER_PYTHONRUNNER_PORT =
+            ConfigProvider.getConfig()
+                    .getOptionalValue("datacater.python-runner.port", Integer.class)
+                    .orElse(50000);
+
+    static final String DATACATER_PYTHONRUNNER_HOST =
+            ConfigProvider.getConfig()
+                    .getOptionalValue("datacater.python-runner.host", String.class)
+                    .orElse("localhost");
+
+    static final String STREAM_IN = "stream-in";
+    static final String STREAM_OUT = "stream-out";
+    static final String ENDPOINT = "/batch";
+    static final String HEADER = "Content-Type";
+    static final String HEADER_TYPE = "application/json";
+    static final String KEY = "key";
+    static final String VALUE = "value";
+    static final String METADATA = "metadata";
+    static final String ERROR = "error";
+    static final String OFFSET = "offset";
+    static final String PARTITION = "partition";
+    static final String PIPELINE_ERROR_MSG = "Pipeline could not process message.\n Key: %s\n Value: %s";
+}

--- a/pipeline/src/main/java/io/datacater/exceptions/Error.java
+++ b/pipeline/src/main/java/io/datacater/exceptions/Error.java
@@ -1,0 +1,28 @@
+package io.datacater.exceptions;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.ws.rs.core.Response;
+
+public class Error {
+  @JsonProperty("statusCode")
+  private int statusCode;
+
+  @JsonProperty("status")
+  private Response.Status status;
+
+  @JsonProperty("message")
+  private String message;
+
+  private Error(int statusCode, Response.Status status, String message) {
+    this.statusCode = statusCode;
+    this.status = status;
+    this.message = message;
+  }
+
+  @JsonCreator
+  public static Error from(int statusCode, Response.Status status, String message) {
+    return new Error(statusCode, status, message);
+  }
+}

--- a/pipeline/src/main/java/io/datacater/exceptions/TransformationException.java
+++ b/pipeline/src/main/java/io/datacater/exceptions/TransformationException.java
@@ -1,0 +1,7 @@
+package io.datacater.exceptions;
+
+public class TransformationException extends RuntimeException {
+  public TransformationException(String message) {
+    super(message);
+  }
+}

--- a/pipeline/src/main/resources/application.yml
+++ b/pipeline/src/main/resources/application.yml
@@ -20,7 +20,7 @@ mp       :
         connector: smallrye-kafka
         topic: stream-out
         key:
-          serializer: org.apache.kafka.common.serialization.UUIDSerializer
+          serializer: io.datacater.core.serde.JsonSerializer
         value:
           serializer: io.datacater.core.serde.JsonSerializer
     incoming:
@@ -32,7 +32,7 @@ mp       :
           poll:
             records: ${datacater.message.batch.size}
         key:
-          deserializer: org.apache.kafka.common.serialization.UUIDDeserializer
+          deserializer: io.datacater.core.serde.JsonDeserializer
         value:
           deserializer: io.datacater.core.serde.JsonDeserializer
 datacater:
@@ -69,6 +69,6 @@ datacater:
           connector: smallrye-kafka
           topic: stream-out
           key:
-            deserializer: org.apache.kafka.common.serialization.UUIDDeserializer
+            deserializer: io.datacater.core.serde.JsonDeserializer
           value:
             deserializer: io.datacater.core.serde.JsonDeserializer

--- a/pipeline/src/main/resources/application.yml
+++ b/pipeline/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 ---
-quarkus:
+quarkus  :
   application:
     name: datacater-pipeline
     version: '1'
@@ -12,20 +12,36 @@ quarkus:
     group: datacater
     name: ${quarkus.application.name}
     tag: ${quarkus.application.version}
-mp     :
+mp       :
   messaging:
     outgoing:
       stream-out:
         merge: true
         connector: smallrye-kafka
         topic: stream-out
+        key:
+          serializer: org.apache.kafka.common.serialization.UUIDSerializer
+        value:
+          serializer: io.datacater.core.serde.JsonSerializer
     incoming:
       stream-in:
+        batch: true
         connector: smallrye-kafka
         topic: stream-in
+        max:
+          poll:
+            records: ${datacater.message.batch.size}
+        key:
+          deserializer: org.apache.kafka.common.serialization.UUIDDeserializer
+        value:
+          deserializer: io.datacater.core.serde.JsonDeserializer
+datacater:
+  message:
+    batch:
+      size: 100
 
 
-'%dev' :
+'%dev'   :
   quarkus:
     log:
       level: INFO
@@ -36,7 +52,7 @@ mp     :
       port: 50000
       host: localhost
 
-'%test':
+'%test'  :
   quarkus:
     log:
       level: INFO

--- a/pipeline/src/main/resources/application.yml
+++ b/pipeline/src/main/resources/application.yml
@@ -1,0 +1,50 @@
+---
+quarkus:
+  application:
+    name: datacater-pipeline
+    version: '1'
+  reactive-messaging:
+    metrics:
+      enabled: true
+    kafka:
+      enable-graceful-shutdown-in-dev-and-test-mode: true
+  container-image:
+    group: datacater
+    name: ${quarkus.application.name}
+    tag: ${quarkus.application.version}
+mp     :
+  messaging:
+    outgoing:
+      pipeline-out:
+        merge: true
+        connector: smallrye-kafka
+        topic: pipeline-out
+    incoming:
+      pipeline-in:
+        connector: smallrye-kafka
+        topic: pipeline-in
+
+
+'%dev' :
+  quarkus:
+    log:
+      level: INFO
+      console:
+        json: false
+  datacater:
+    python-runner:
+      port: 50000
+      host: localhost
+
+'%test':
+  quarkus:
+    log:
+      level: INFO
+      console:
+        json: false
+  mp:
+    messaging:
+      outgoing:
+        pipeline-in-test:
+          connector: smallrye-kafka
+          topic: pipeline-in

--- a/pipeline/src/main/resources/application.yml
+++ b/pipeline/src/main/resources/application.yml
@@ -48,3 +48,11 @@ mp     :
         pipeline-in-test:
           connector: smallrye-kafka
           topic: pipeline-in
+      incoming:
+        pipeline-out-test:
+          connector: smallrye-kafka
+          topic: pipeline-out
+          key:
+            deserializer: org.apache.kafka.common.serialization.UUIDDeserializer
+          value:
+            deserializer: io.datacater.core.serde.JsonDeserializer

--- a/pipeline/src/main/resources/application.yml
+++ b/pipeline/src/main/resources/application.yml
@@ -15,14 +15,14 @@ quarkus:
 mp     :
   messaging:
     outgoing:
-      pipeline-out:
+      stream-out:
         merge: true
         connector: smallrye-kafka
-        topic: pipeline-out
+        topic: stream-out
     incoming:
-      pipeline-in:
+      stream-in:
         connector: smallrye-kafka
-        topic: pipeline-in
+        topic: stream-in
 
 
 '%dev' :
@@ -45,13 +45,13 @@ mp     :
   mp:
     messaging:
       outgoing:
-        pipeline-in-test:
+        stream-in-test:
           connector: smallrye-kafka
-          topic: pipeline-in
+          topic: stream-in
       incoming:
-        pipeline-out-test:
+        stream-out-test:
           connector: smallrye-kafka
-          topic: pipeline-out
+          topic: stream-out
           key:
             deserializer: org.apache.kafka.common.serialization.UUIDDeserializer
           value:

--- a/pipeline/src/main/resources/sample-.testcontainers.properties
+++ b/pipeline/src/main/resources/sample-.testcontainers.properties
@@ -1,0 +1,4 @@
+registryUrl=ghcr.io
+registryUsername={{github user}}
+registryPassword={{github access token with package:read rights}}
+registryEmail={{github email}}

--- a/pipeline/src/main/resources/sample-.testcontainers.properties
+++ b/pipeline/src/main/resources/sample-.testcontainers.properties
@@ -1,4 +1,0 @@
-registryUrl=ghcr.io
-registryUsername={{github user}}
-registryPassword={{github access token with package:read rights}}
-registryEmail={{github email}}

--- a/pipeline/src/test/java/io/datacater/PipelineTest.java
+++ b/pipeline/src/test/java/io/datacater/PipelineTest.java
@@ -1,0 +1,83 @@
+package io.datacater;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.core.json.JsonObject;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import javax.inject.Inject;
+import java.util.UUID;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+@QuarkusTest
+class PipelineTest {
+    private static final Logger LOGGER = Logger.getLogger(PipelineTest.class);
+
+    private static final String PIPELINE_IN = "pipeline-in-test";
+    @Inject
+    Pipeline application;
+
+    @Inject
+    @Channel(PIPELINE_IN)
+    Emitter<ProducerRecord<UUID, JsonObject>> producer;
+
+
+    private static final Integer DATACATER_PYTHONRUNNER_PORT =
+            ConfigProvider.getConfig()
+                    .getOptionalValue("datacater.python-runner.port", Integer.class)
+                    .orElse(50000);
+
+    private static final String DATACATER_PYTHONRUNNER_IMAGE =
+            ConfigProvider.getConfig()
+                    .getOptionalValue("datacater.python-runner.image", String.class)
+                    .orElse("datacater/python-runner");
+
+    private static final String DATACATER_PYTHONRUNNER_VERSION =
+            ConfigProvider.getConfig()
+                    .getOptionalValue("datacater.python-runner.version", String.class)
+                    .orElse("alpha");
+
+
+    private static final GenericContainer<?> pythonRunner = new GenericContainer<>(DockerImageName.parse(DATACATER_PYTHONRUNNER_IMAGE).withTag(DATACATER_PYTHONRUNNER_VERSION))
+            .withExposedPorts(DATACATER_PYTHONRUNNER_PORT).waitingFor(Wait.forHttp("/health"));
+
+    @BeforeEach
+    void setUp() {
+        pythonRunner.start();
+    }
+
+    @Test
+    void vertxResource() throws ExecutionException, InterruptedException, TimeoutException {
+        application.setNetwork(pythonRunner.getMappedPort(DATACATER_PYTHONRUNNER_PORT), pythonRunner.getHost());
+
+         JsonObject message = new JsonObject();
+         message.put("name", "Max Mustermann");
+         message.put("email", "max-mustermann@datacater.io");
+         message.put("is_admin", "true");
+
+        CompletionStage<Void> messageToWaitOn = producer.send( new ProducerRecord<>(
+                "pipeline-in",
+                UUID.randomUUID(),
+                message));
+
+        messageToWaitOn.toCompletableFuture().get(1000, TimeUnit.MILLISECONDS);
+
+
+
+
+        //TODO (ChrisRousey): consume message from "pipeline-out" and check if a standard transform worked
+        //TODO (ChrisRousey): need a working example of python runner message, right now python runner always has error
+    }
+
+}

--- a/pipeline/src/test/java/io/datacater/PipelineTest.java
+++ b/pipeline/src/test/java/io/datacater/PipelineTest.java
@@ -1,27 +1,18 @@
 package io.datacater;
 
-import io.datacater.exceptions.TransformationException;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.kafka.InjectKafkaCompanion;
 import io.quarkus.test.kafka.KafkaCompanionResource;
-import io.smallrye.common.annotation.Blocking;
-import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.Uni;
-import io.smallrye.reactive.messaging.kafka.Record;
 import io.smallrye.reactive.messaging.kafka.companion.ConsumerTask;
 import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
-import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.serialization.UUIDDeserializer;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.reactive.messaging.*;
 import org.jboss.logging.Logger;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.reactivestreams.Publisher;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
@@ -38,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @QuarkusTest
 @QuarkusTestResource(KafkaCompanionResource.class)
 class PipelineTest {
+    private static final Logger LOGGER = Logger.getLogger(PipelineTest.class);
     private static final String STREAM_IN = "stream-in-test";
     private static final String STREAM_OUT = "stream-out";
     @Inject
@@ -84,6 +76,12 @@ class PipelineTest {
          message.put("email", "max-mustermann@datacater.io");
          message.put("is_admin", "true");
 
+        for(int i = 1; i < 300; i++){
+            producer.send( new ProducerRecord<>(
+                    "stream-in",
+                    UUID.randomUUID(),
+                    message.put("number", i)));
+        }
         CompletionStage<Void> messageToWaitOn = producer.send( new ProducerRecord<>(
                 "stream-in",
                 UUID.randomUUID(),

--- a/pipeline/src/test/java/io/datacater/PipelineTest.java
+++ b/pipeline/src/test/java/io/datacater/PipelineTest.java
@@ -38,13 +38,13 @@ import static org.junit.jupiter.api.Assertions.*;
 @QuarkusTest
 @QuarkusTestResource(KafkaCompanionResource.class)
 class PipelineTest {
-    private static final String PIPELINE_IN = "pipeline-in-test";
-    private static final String PIPELINE_OUT = "pipeline-out";
+    private static final String STREAM_IN = "stream-in-test";
+    private static final String STREAM_OUT = "stream-out";
     @Inject
     Pipeline application;
 
     @Inject
-    @Channel(PIPELINE_IN)
+    @Channel(STREAM_IN)
     Emitter<ProducerRecord<UUID, JsonObject>> producer;
 
     @InjectKafkaCompanion
@@ -85,13 +85,13 @@ class PipelineTest {
          message.put("is_admin", "true");
 
         CompletionStage<Void> messageToWaitOn = producer.send( new ProducerRecord<>(
-                "pipeline-in",
+                "stream-in",
                 UUID.randomUUID(),
                 message));
 
         messageToWaitOn.toCompletableFuture().get(1000, TimeUnit.MILLISECONDS);
 
-        ConsumerTask<Object, Object> messages = companion.consumeWithDeserializers(org.apache.kafka.common.serialization.UUIDDeserializer.class, io.datacater.core.serde.JsonDeserializer.class).fromTopics(PIPELINE_OUT,1).awaitCompletion();
+        ConsumerTask<Object, Object> messages = companion.consumeWithDeserializers(org.apache.kafka.common.serialization.UUIDDeserializer.class, io.datacater.core.serde.JsonDeserializer.class).fromTopics(STREAM_OUT,1).awaitCompletion();
         assertTrue(messages.getFirstRecord().value().toString().contains("max-mustermann@datacater.io"));
         assertEquals(1, messages.count());
     }

--- a/pipeline/src/test/java/io/datacater/PipelineTest.java
+++ b/pipeline/src/test/java/io/datacater/PipelineTest.java
@@ -33,14 +33,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 @QuarkusTest
 @QuarkusTestResource(KafkaCompanionResource.class)
 class PipelineTest {
-    private static final Logger LOGGER = Logger.getLogger(PipelineTest.class);
-
     private static final String PIPELINE_IN = "pipeline-in-test";
     private static final String PIPELINE_OUT = "pipeline-out";
     @Inject
@@ -95,6 +92,7 @@ class PipelineTest {
         messageToWaitOn.toCompletableFuture().get(1000, TimeUnit.MILLISECONDS);
 
         ConsumerTask<Object, Object> messages = companion.consumeWithDeserializers(org.apache.kafka.common.serialization.UUIDDeserializer.class, io.datacater.core.serde.JsonDeserializer.class).fromTopics(PIPELINE_OUT,1).awaitCompletion();
+        assertTrue(messages.getFirstRecord().value().toString().contains("max-mustermann@datacater.io"));
         assertEquals(1, messages.count());
     }
 }

--- a/platform-api/src/main/resources/application.yml
+++ b/platform-api/src/main/resources/application.yml
@@ -49,7 +49,7 @@ smallrye :
   jwt:
     sign:
       key:
-        location: privateKey.pem
+        location: cert.pem
     new-token:
       lifespan: 7200
 mp       :
@@ -57,7 +57,7 @@ mp       :
     verify:
       issuer: https://datacater.io
       publickey:
-        location: publicKey.pem
+        location: key.pem
 datacater:
   pythonrunner:
     image:
@@ -112,9 +112,9 @@ datacater:
   mp:
     jwt:
       verify:
-        issuer: https://cloud.datacater.io
+        issuer: localhost
         publickey:
-          location: publicKey.pem
+          location: key.pem
     messaging:
       connector:
         smallrye-kafka:
@@ -125,7 +125,7 @@ datacater:
     jwt:
       sign:
         key:
-          location: privateKey.pem
+          location: cert.pem
       new-token:
         lifespan: 7200
 
@@ -173,9 +173,9 @@ datacater:
   mp:
     jwt:
       verify:
-        issuer: https://cloud.datacater.io
+        issuer: localhost
         publickey:
-          location: publicKey.pem
+          location: key.pem
     messaging:
       outgoing:
         testStreamTopicOutAvro:
@@ -195,6 +195,6 @@ datacater:
     jwt:
       sign:
         key:
-          location: privateKey.pem
+          location: key.pem
       new-token:
         lifespan: 7200

--- a/python-runner/README.md
+++ b/python-runner/README.md
@@ -28,7 +28,7 @@ Send a request:
 ```
 $ curl http://localhost:8000/batch \
   -XPOST \
-  -H'Content-Type:application/json'
+  -H'Content-Type:application/json' \
   -d'
   [{
     "key": null,

--- a/python-runner/runner.py
+++ b/python-runner/runner.py
@@ -206,7 +206,7 @@ async def apply_to_single_record(record: Record):
 async def apply_to_multiple_records(records: List[Record], response: Response):
     processed_records = []
     for record in records:
-        processed_record = apply_pipeline(record, ipeline)
+        processed_record = apply_pipeline(record, pipeline)
         if processed_record is not None:
             processed_records.append(record)
             return processed_records

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,4 +11,4 @@ pluginManagement {
 
 rootProject.name = 'datacater'
 
-include 'platform-api', 'serde'
+include 'platform-api', 'serde', 'pipeline'


### PR DESCRIPTION
This PR is for the implementation of the Datacater Pipeline Concept.

- Messages are to be consumed from the definded stream-in
- Forwarded to a Datacater Python-runner
    * Here, it is processed (transformed and or filtered)
- The processed message is produced to the defined stream-out


The defined test will currently not work, as there is a bug in the currently deployed python-runner on the `/batch` endpoint. I fixed the endpoint in the PR. 

To test manually, the python runner and be run locally:
1. `pip3 install -r requirements.txt`
2. `python3 -m uvicorn runner:app`

And by then setting environment variables:
- `DATACATER_PYTHONRUNNER_PORT=8000`
- `DATACATER_PYTHONRUNNER_HOST=localhost`