### PR TITLE
feat(helm): Ensure compatibility with latest app version

### DIFF
--- a/helm-charts/datacater/Chart.yaml
+++ b/helm-charts/datacater/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
   - name: DataCater
     url: https://datacater.io
 
-appVersion: "2022.06"
+appVersion: "alpha-20221109-1"

--- a/helm-charts/datacater/templates/statefulset.yaml
+++ b/helm-charts/datacater/templates/statefulset.yaml
@@ -51,7 +51,7 @@ spec:
           livenessProbe:
             failureThreshold: 3
             httpGet:
-              path: /q/health/live
+              path: /api/alpha/q/health/live
               port: 8080
               scheme: HTTP
             initialDelaySeconds: 10
@@ -61,7 +61,7 @@ spec:
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              path: /q/health/ready
+              path: /api/alpha/q/health/ready
               port: 8080
               scheme: HTTP
             initialDelaySeconds: 10

--- a/helm-charts/datacater/templates/ui.yaml
+++ b/helm-charts/datacater/templates/ui.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
 spec:
   containers:
-    - image: datacater/ui:alpha
+    - image: datacater/ui:alpha-20221109-1
       imagePullPolicy: IfNotPresent
       name: ui
       ports:

--- a/helm-charts/datacater/values.yaml
+++ b/helm-charts/datacater/values.yaml
@@ -9,7 +9,7 @@ image:
   repository: datacater/datacater
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 'alpha'
+  tag: 'alpha-20221109-1'
 
 # GitHub personal access tokens will be used until we publish to docker io
 # Follow instructions -> https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry
@@ -37,13 +37,13 @@ env:
   - name: QUARKUS_DATASOURCE_PASSWORD
     value: datacater
   - name: DATACATER_TRANSFORMS_PATH
-    value: "/transforms"
+    value: "/datacater/transforms"
   - name: DATACATER_FILTERS_PATH
-    value: "/filters"
+    value: "/datacater/filters"
   - name: DATACATER_PYTHONRUNNER_IMAGE_NAME
     value: 'datacater/python-runner'
   - name: DATACATER_PYTHONRUNNER_IMAGE_VERSION
-    value: 'alpha'
+    value: 'alpha-20221109-1'
   - name: QUARKUS_LOG_CONSOLE_JSON
     value: "false"
 

--- a/k8s-manifests/minikube-with-postgres-ns-default.yaml
+++ b/k8s-manifests/minikube-with-postgres-ns-default.yaml
@@ -111,7 +111,7 @@ metadata:
   namespace: default
 spec:
   containers:
-    - image: datacater/ui:alpha
+    - image: datacater/ui:alpha-20221109-1
       imagePullPolicy: IfNotPresent
       name: ui
       ports:
@@ -235,7 +235,7 @@ spec:
         - name: datacater
           securityContext:
             {}
-          image: "datacater/datacater:alpha.15"
+          image: "datacater/datacater:alpha-20221109-1"
           imagePullPolicy: IfNotPresent
           env:
             - name: QUARKUS_DATASOURCE_REACTIVE_URL
@@ -247,13 +247,13 @@ spec:
             - name: QUARKUS_DATASOURCE_PASSWORD
               value: datacater
             - name: DATACATER_TRANSFORMS_PATH
-              value: /transforms
+              value: /datacater/transforms
             - name: DATACATER_FILTERS_PATH
-              value: /filters
+              value: /datacater/filters
             - name: DATACATER_PYTHONRUNNER_IMAGE_NAME
               value: datacater/python-runner
             - name: DATACATER_PYTHONRUNNER_IMAGE_VERSION
-              value: alpha
+              value: alpha-20221109-1
             - name: QUARKUS_LOG_CONSOLE_JSON
               value: "false"
           ports:
@@ -263,7 +263,7 @@ spec:
           livenessProbe:
             failureThreshold: 3
             httpGet:
-              path: /q/health/live
+              path: /api/alpha/q/health/live
               port: 8080
               scheme: HTTP
             initialDelaySeconds: 10
@@ -273,7 +273,7 @@ spec:
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              path: /q/health/ready
+              path: /api/alpha/q/health/ready
               port: 8080
               scheme: HTTP
             initialDelaySeconds: 10


### PR DESCRIPTION
Update the Helm chart and Kubernetes manifest to be compatible with the most recent version of our application:

* Update all images to most recent release, i.e., `alpha-20221109-1`
* Add prefix to `DATACATER_FILTERS_PATH` and `DATACATER_TRANSFORMS_PATH`
* Add prefix to paths of liveness and readiness probes