### PR TITLE
feat(ui): Note if a filter or transform does not require any config

### DIFF
--- a/ui/src/components/pipelines/pipeline_designer/context_bar/FilterConfig.js
+++ b/ui/src/components/pipelines/pipeline_designer/context_bar/FilterConfig.js
@@ -188,6 +188,12 @@ class FilterConfig extends Component {
                   <i>{fieldDataType}</i>.
                 </div>
               )}
+              {(filter.config === undefined ||
+                Object.keys(filter.config).length === 0) && (
+                <div className="alert alert-primary">
+                  This filter does not require any configuration.
+                </div>
+              )}
               {filter.config !== undefined &&
                 filter.config.map((configOption, idx) => (
                   <div key={idx}>

--- a/ui/src/components/pipelines/pipeline_designer/context_bar/TransformConfig.js
+++ b/ui/src/components/pipelines/pipeline_designer/context_bar/TransformConfig.js
@@ -206,6 +206,12 @@ class TransformConfig extends Component {
                   input type <i>{fieldDataType}</i>.
                 </div>
               )}
+              {(transform.config === undefined ||
+                Object.keys(transform.config).length === 0) && (
+                <div className="alert alert-primary">
+                  This transform does not require any configuration.
+                </div>
+              )}
               {transform.config !== undefined &&
                 transform.config.map((configOption, idx) => (
                   <div key={idx}>


### PR DESCRIPTION
Let the user know if a filter or transform does not require any configuration instead of keeping the "Config" tab in the sidebar empty.

Before:
![Screenshot 2022-11-10 at 14 32 01](https://user-images.githubusercontent.com/128683/201105308-3d52dd4f-5bbe-4ef5-9207-5397aeddb206.png)

After:
![Screenshot 2022-11-10 at 14 31 49](https://user-images.githubusercontent.com/128683/201105349-9acca15a-c69e-4199-b62d-ad09ffc91007.png)
