### PR TITLE
feat(ui): Improve API Call Widget

### DIFF
--- a/ui/src/components/layout/Header.js
+++ b/ui/src/components/layout/Header.js
@@ -1,0 +1,159 @@
+import React, { Component } from "react";
+import { Copy } from "react-feather";
+import { getApiPathPrefix } from "../../helpers/getApiPathPrefix";
+
+class Header extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      showApiCall: false,
+      showToken: false,
+    };
+    this.toggleShowApiCall = this.toggleShowApiCall.bind(this);
+    this.toggleShowToken = this.toggleShowToken.bind(this);
+  }
+
+  toggleShowToken(event) {
+    event.preventDefault();
+
+    this.setState({
+      showToken: !this.state.showToken,
+    });
+  }
+
+  toggleShowApiCall(event) {
+    event.preventDefault();
+
+    const newShowApiCall = !this.state.showApiCall;
+
+    if (this.props.updateCallback !== undefined) {
+      this.props.updateCallback(newShowApiCall);
+    }
+
+    this.setState({
+      showApiCall: newShowApiCall,
+    });
+  }
+
+  render() {
+    const {
+      apiDocs,
+      apiPath,
+      buttons,
+      httpMethod,
+      requestBody,
+      subTitle,
+      title,
+    } = this.props;
+
+    const token = this.state.showToken
+      ? localStorage.getItem("userToken")
+      : "YOUR_TOKEN";
+    const tokenClassName = this.state.showToken ? "" : "text-purple";
+
+    let curlCommand = `curl ${getApiPathPrefix(
+      true
+    )}${apiPath} -H'Authorization: Bearer ${token}'`;
+
+    if (httpMethod !== undefined) {
+      curlCommand = curlCommand + ` -X${httpMethod}`;
+    }
+
+    if (requestBody !== undefined) {
+      curlCommand =
+        curlCommand +
+        ` -H'Content-Type:application/json' -d'${JSON.stringify(requestBody)}'`;
+    }
+
+    return (
+      <div className="col-12 mt-3">
+        <div className="card welcome-card py-2 bg-gradient-purple">
+          <div className="card-body text-center p-0">
+            <div className="row justify-content-center align-items-center">
+              <div className="col-12 col-lg-6 mb-2 mb-lg-0 text-start">
+                <h4 className="fw-semibold mb-0">{title}</h4>
+                {subTitle !== undefined && (
+                  <p className="text-white mb-0">{subTitle}</p>
+                )}
+              </div>
+              <div className="col-12 col-lg-6 d-flex align-items-center justify-content-lg-end">
+                <div>
+                  <a
+                    href="#"
+                    className="btn btn-light btn-pill"
+                    onClick={this.toggleShowApiCall}
+                  >
+                    {this.state.showApiCall ? "Hide" : "Show"} API call
+                  </a>
+                  {buttons}
+                </div>
+              </div>
+            </div>
+            {this.state.showApiCall && (
+              <div className="bg-black mx-n3 p-3 mt-2 mb-n3 text-start position-relative">
+                <p
+                  className="position-absolute"
+                  style={{ right: "5px", top: "5px" }}
+                >
+                  <a
+                    href="#"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="btn btn-sm btn-light me-2"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      navigator.clipboard.writeText(curlCommand);
+                    }}
+                  >
+                    <Copy className="feather-icon" />
+                  </a>
+                  <a
+                    href="#"
+                    className="btn btn-sm btn-light me-2"
+                    onClick={this.toggleShowToken}
+                  >
+                    {!this.state.showToken && "Show token"}
+                    {this.state.showToken && "Hide token"}
+                  </a>
+                  <a
+                    href={apiDocs}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="btn btn-sm btn-light"
+                  >
+                    Docs
+                  </a>
+                </p>
+                <pre className="mb-0">
+                  <code className="text-white">
+                    <span className="text-blue-light">$</span> curl{" "}
+                    {getApiPathPrefix(true)}
+                    {apiPath} \<br />
+                    {httpMethod !== undefined && (
+                      <>
+                        <span className="me-2"></span> -X{httpMethod} \<br />
+                      </>
+                    )}
+                    {requestBody !== undefined && (
+                      <>
+                        <span className="me-2"></span>{" "}
+                        -H&apos;Content-Type:application/json&apos; \<br />
+                        <span className="me-2"></span> -d&apos;
+                        {JSON.stringify(requestBody)}&apos; \<br />
+                      </>
+                    )}
+                    <span className="me-2"></span> -H&apos;Authorization:Bearer{" "}
+                    <span className={tokenClassName}>{token}</span>&apos;
+                    <br />
+                  </code>
+                </pre>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default Header;

--- a/ui/src/containers/Home.js
+++ b/ui/src/containers/Home.js
@@ -38,10 +38,7 @@ class Home extends Component {
           <main role="main" className="col-10 mx-auto pt-3 px-4">
             <div className="row">
               <div className="col-12">
-                <div
-                  className="card welcome-card mt-2"
-                  style={{ backgroundImage: "url(/images/bg-card.jpg)" }}
-                >
+                <div className="card welcome-card mt-2 bg-gradient-purple">
                   <div className="card-body text-center">
                     <div className="row justify-content-center">
                       <div className="col-12">

--- a/ui/src/containers/deployments/DeploymentLogs.js
+++ b/ui/src/containers/deployments/DeploymentLogs.js
@@ -1,9 +1,8 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { Copy, Trash2 } from "react-feather";
 import { Redirect } from "react-router-dom";
 import Breadcrumb from "../../components/layout/Breadcrumb";
-import { getApiPathPrefix } from "../../helpers/getApiPathPrefix";
+import Header from "../../components/layout/Header";
 import {
   fetchDeployment,
   fetchDeploymentLogs,
@@ -14,11 +13,9 @@ class DeploymentLogs extends Component {
     super(props);
     this.state = {
       followLogs: false,
-      showApiCall: false,
       logMessages: [],
       wrapLines: false,
     };
-    this.toggleShowApiCall = this.toggleShowApiCall.bind(this);
     this.fetchLogs = this.fetchLogs.bind(this);
     this.toggleFollowLogs = this.toggleFollowLogs.bind(this);
     this.toggleWrapLines = this.toggleWrapLines.bind(this);
@@ -118,73 +115,11 @@ class DeploymentLogs extends Component {
               { name: "Logs" },
             ]}
           />
-          <div className="col-12 mt-3">
-            <div
-              className="card welcome-card py-2"
-              style={{ backgroundImage: "url(/images/bg-card.jpg)" }}
-            >
-              <div className="card-body text-center p-0">
-                <div className="row justify-content-center">
-                  <div className="col-6 text-start d-flex align-items-center">
-                    <h4 className="fw-semibold mb-0">
-                      {deployment.name || "Untitled deployment"}
-                    </h4>
-                  </div>
-                  <div className="col-6 d-flex align-items-center justify-content-end">
-                    <div>
-                      <a
-                        href="/deployments"
-                        className="btn btn-light btn-pill"
-                        onClick={this.toggleShowApiCall}
-                      >
-                        {this.state.showApiCall ? "Hide" : "Show"} API call
-                      </a>
-                    </div>
-                  </div>
-                </div>
-                {this.state.showApiCall && (
-                  <div className="bg-black mx-n3 p-3 mt-3 mb-n3 text-start">
-                    <pre className="mb-0">
-                      <a
-                        href="https://docs.datacater.io/docs/api/deployments/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="btn btn-sm btn-light float-end"
-                      >
-                        See docs
-                      </a>
-                      <a
-                        href="/deployments/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="btn btn-sm btn-light me-2 float-end"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          navigator.clipboard.writeText(
-                            "curl " +
-                              getApiPathPrefix(true) +
-                              "/deployments/" +
-                              deployment.uuid +
-                              " -H'Authorization:Bearer YOUR_TOKEN'"
-                          );
-                        }}
-                      >
-                        <Copy className="feather-icon" />
-                      </a>
-                      <code className="text-white">
-                        $ curl {getApiPathPrefix(true)}/deployments/
-                        {deployment.uuid}/logs \
-                        <br />
-                        <span className="me-2"></span>{" "}
-                        -H&apos;Authorization:Bearer YOUR_TOKEN&apos;
-                        <br />
-                      </code>
-                    </pre>
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
+          <Header
+            apiDocs="https://docs.datacater.io/docs/api/deployments/"
+            apiPath={`/deployments/${deployment.uuid}/logs`}
+            title={deployment.name || "Untitled deployment"}
+          />
         </div>
         <div className="row mt-4">
           <div className="col-12">

--- a/ui/src/containers/deployments/EditDeployment.js
+++ b/ui/src/containers/deployments/EditDeployment.js
@@ -1,12 +1,11 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { Redirect } from "react-router-dom";
-import { Copy } from "react-feather";
 import Select from "react-select";
 import Breadcrumb from "../../components/layout/Breadcrumb";
+import Header from "../../components/layout/Header";
 import { fetchDeployment, updateDeployment } from "../../actions/deployments";
 import { fetchPipelines } from "../../actions/pipelines";
-import { getApiPathPrefix } from "../../helpers/getApiPathPrefix";
 import "../../scss/fonts.scss";
 
 class EditDeployment extends Component {
@@ -16,14 +15,12 @@ class EditDeployment extends Component {
     this.state = {
       updatingDeploymentFailed: false,
       errorMessages: {},
-      showApiCall: false,
       deployment: undefined,
       deploymentUpdated: false,
     };
 
     this.handleUpdateDeployment = this.handleUpdateDeployment.bind(this);
     this.handleChange = this.handleChange.bind(this);
-    this.toggleShowApiCall = this.toggleShowApiCall.bind(this);
   }
 
   componentDidMount() {
@@ -77,14 +74,6 @@ class EditDeployment extends Component {
     });
   }
 
-  toggleShowApiCall(event) {
-    event.preventDefault();
-
-    this.setState({
-      showApiCall: !this.state.showApiCall,
-    });
-  }
-
   render() {
     if (this.state.deploymentUpdated) {
       return <Redirect to={`/deployments/${this.getDeploymentId()}`} />;
@@ -116,77 +105,13 @@ class EditDeployment extends Component {
               { name: "Edit" },
             ]}
           />
-          <div className="col-12 mt-3">
-            <div
-              className="card welcome-card py-2"
-              style={{ backgroundImage: "url(/images/bg-card.jpg)" }}
-            >
-              <div className="card-body text-center p-0">
-                <div className="row justify-content-center align-items-center">
-                  <div className="col-10 text-start">
-                    <h4 className="fw-semibold mb-0">
-                      {deployment.name || "Untitled deployment"}
-                    </h4>
-                  </div>
-                  <div className="col-2 d-flex align-items-center justify-content-end">
-                    <a
-                      href="/deployments/edit"
-                      className="btn btn-light btn-pill"
-                      onClick={this.toggleShowApiCall}
-                    >
-                      {this.state.showApiCall ? "Hide" : "Show"} API call
-                    </a>
-                  </div>
-                </div>
-                {this.state.showApiCall && (
-                  <div className="bg-black mx-n3 p-3 mt-3 mb-n3 text-start">
-                    <pre className="mb-0">
-                      <a
-                        href="https://docs.datacater.io/docs/api/deployments/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="btn btn-sm btn-light float-end"
-                      >
-                        See docs
-                      </a>
-                      <a
-                        href="/deployments/new/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="btn btn-sm btn-light me-2 float-end"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          navigator.clipboard.writeText(
-                            "curl " +
-                              getApiPathPrefix(true) +
-                              "/deployments/" +
-                              deployment.uuid +
-                              " -XPUT -H'Content-Type:application/json' -H'Authorization:Bearer YOUR_TOKEN' -d'" +
-                              JSON.stringify(apiPayload) +
-                              "'"
-                          );
-                        }}
-                      >
-                        <Copy className="feather-icon" />
-                      </a>
-                      <code className="text-white">
-                        $ curl {getApiPathPrefix(true)}/deployments/
-                        {deployment.uuid} \
-                        <br />
-                        <span className="me-2"></span> -XPUT \<br />
-                        <span className="me-2"></span>{" "}
-                        -H&apos;Authorization:Bearer YOUR_TOKEN&apos; \<br />
-                        <span className="me-2"></span>{" "}
-                        -H&apos;Content-Type:application/json&apos; \<br />
-                        <span className="me-2"></span> -d&apos;
-                        {JSON.stringify(apiPayload)}&apos;
-                      </code>
-                    </pre>
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
+          <Header
+            apiDocs="https://docs.datacater.io/docs/api/deployments/"
+            apiPath={`/deployments/${deployment.uuid}`}
+            httpMethod="PUT"
+            requestBody={apiPayload}
+            title={deployment.name || "Untitled deployment"}
+          />
           <form>
             <div className="col-12 mt-4">
               <label htmlFor="name" className="form-label">

--- a/ui/src/containers/deployments/ListDeployments.js
+++ b/ui/src/containers/deployments/ListDeployments.js
@@ -1,29 +1,12 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { Copy } from "react-feather";
 import Breadcrumb from "../../components/layout/Breadcrumb";
-import { getApiPathPrefix } from "../../helpers/getApiPathPrefix";
+import Header from "../../components/layout/Header";
 import { fetchDeployments } from "../../actions/deployments";
 
 class ListDeployments extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      showApiCall: false,
-    };
-    this.toggleShowApiCall = this.toggleShowApiCall.bind(this);
-  }
-
   componentDidMount() {
     this.props.fetchDeployments();
-  }
-
-  toggleShowApiCall(event) {
-    event.preventDefault();
-
-    this.setState({
-      showApiCall: !this.state.showApiCall,
-    });
   }
 
   render() {
@@ -46,78 +29,24 @@ class ListDeployments extends Component {
       <div className="container">
         <div className="row">
           <Breadcrumb items={[{ name: "Deployments" }]} />
-          <div className="col-12 mt-3">
-            <div
-              className="card welcome-card py-2"
-              style={{ backgroundImage: "url(/images/bg-card.jpg)" }}
-            >
-              <div className="card-body text-center p-0">
-                <div className="row justify-content-center">
-                  <div className="col-8 text-start">
-                    <h4 className="fw-semibold mb-0">Deployments</h4>
-                    <p className="text-white mb-0">
-                      Deployments operate Pipelines.
-                    </p>
-                  </div>
-                  <div className="col-4 d-flex align-items-center justify-content-end">
-                    <div>
-                      <a
-                        href="/deployments"
-                        className="btn btn-light btn-pill"
-                        onClick={this.toggleShowApiCall}
-                      >
-                        {this.state.showApiCall ? "Hide" : "Show"} API call
-                      </a>
-                      {deployments.length > 0 && (
-                        <a
-                          href="/deployments/new"
-                          className="btn btn-primary text-white ms-2"
-                        >
-                          Create new deployment
-                        </a>
-                      )}
-                    </div>
-                  </div>
-                </div>
-                {this.state.showApiCall && (
-                  <div className="bg-black mx-n3 p-3 mt-3 mb-n3 text-start">
-                    <pre className="mb-0">
-                      <a
-                        href="https://docs.datacater.io/docs/api/deployments/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="btn btn-sm btn-light float-end"
-                      >
-                        See docs
-                      </a>
-                      <a
-                        href="/deployments/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="btn btn-sm btn-light me-2 float-end"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          navigator.clipboard.writeText(
-                            "curl " +
-                              getApiPathPrefix(true) +
-                              "/deployments -H'Authorization:Bearer YOUR_TOKEN'"
-                          );
-                        }}
-                      >
-                        <Copy className="feather-icon" />
-                      </a>
-                      <code className="text-white">
-                        $ curl {getApiPathPrefix(true)}/deployments/ \<br />
-                        <span className="me-2"></span>{" "}
-                        -H&apos;Authorization:Bearer YOUR_TOKEN&apos;
-                        <br />
-                      </code>
-                    </pre>
-                  </div>
+          <Header
+            apiDocs="https://docs.datacater.io/docs/api/deployments/"
+            apiPath="/deployments/"
+            buttons={
+              <>
+                {deployments.length > 0 && (
+                  <a
+                    href="/deployments/new"
+                    className="btn btn-primary text-white ms-2"
+                  >
+                    Create new deployment
+                  </a>
                 )}
-              </div>
-            </div>
-          </div>
+              </>
+            }
+            title="Deployments"
+            subTitle="Deployments operate Pipelines."
+          />
         </div>
         <div className="row mt-4">
           <div className="col-12">

--- a/ui/src/containers/deployments/NewDeployment.js
+++ b/ui/src/containers/deployments/NewDeployment.js
@@ -2,11 +2,10 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { Redirect } from "react-router-dom";
 import Select from "react-select";
-import { Copy } from "react-feather";
 import Breadcrumb from "../../components/layout/Breadcrumb";
+import Header from "../../components/layout/Header";
 import { addDeployment } from "../../actions/deployments";
 import { fetchPipelines } from "../../actions/pipelines";
-import { getApiPathPrefix } from "../../helpers/getApiPathPrefix";
 import "../../scss/fonts.scss";
 
 class NewDeployment extends Component {
@@ -16,7 +15,6 @@ class NewDeployment extends Component {
     this.state = {
       creatingDeploymentFailed: false,
       errorMessages: {},
-      showApiCall: false,
       deployment: {
         spec: {},
       },
@@ -25,7 +23,6 @@ class NewDeployment extends Component {
 
     this.handleCreateDeployment = this.handleCreateDeployment.bind(this);
     this.handleChange = this.handleChange.bind(this);
-    this.toggleShowApiCall = this.toggleShowApiCall.bind(this);
   }
 
   componentDidMount() {
@@ -68,14 +65,6 @@ class NewDeployment extends Component {
     });
   }
 
-  toggleShowApiCall(event) {
-    event.preventDefault();
-
-    this.setState({
-      showApiCall: !this.state.showApiCall,
-    });
-  }
-
   render() {
     if (this.state.deploymentCreated) {
       return (
@@ -101,74 +90,14 @@ class NewDeployment extends Component {
               { name: "New deployment" },
             ]}
           />
-          <div className="col-12 mt-3">
-            <div
-              className="card welcome-card py-2"
-              style={{ backgroundImage: "url(/images/bg-card.jpg)" }}
-            >
-              <div className="card-body text-center p-0">
-                <div className="row justify-content-center">
-                  <div className="col-10 text-start">
-                    <h4 className="fw-semibold mb-0">Create new deployment</h4>
-                    <p className="text-white mb-0">
-                      Deployments operate Pipelines.
-                    </p>
-                  </div>
-                  <div className="col-2 d-flex align-items-center justify-content-end">
-                    <a
-                      href="/deployments/new"
-                      className="btn btn-light btn-pill"
-                      onClick={this.toggleShowApiCall}
-                    >
-                      {this.state.showApiCall ? "Hide" : "Show"} API call
-                    </a>
-                  </div>
-                </div>
-                {this.state.showApiCall && (
-                  <div className="bg-black mx-n3 p-3 mt-3 mb-n3 text-start">
-                    <pre className="mb-0">
-                      <a
-                        href="https://docs.datacater.io/docs/api/deployments/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="btn btn-sm btn-light float-end"
-                      >
-                        See docs
-                      </a>
-                      <a
-                        href="/deployments/new/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="btn btn-sm btn-light me-2 float-end"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          navigator.clipboard.writeText(
-                            "curl " +
-                              getApiPathPrefix(true) +
-                              "/deployments -XPOST -H'Content-Type:application/json' -H'Authorization:Bearer YOUR_TOKEN' -d'" +
-                              JSON.stringify(this.state.deployment) +
-                              "'"
-                          );
-                        }}
-                      >
-                        <Copy className="feather-icon" />
-                      </a>
-                      <code className="text-white">
-                        $ curl {getApiPathPrefix(true)}/deployments/ \<br />
-                        <span className="me-2"></span> -XPOST \<br />
-                        <span className="me-2"></span>{" "}
-                        -H&apos;Authorization:Bearer YOUR_TOKEN&apos; \<br />
-                        <span className="me-2"></span>{" "}
-                        -H&apos;Content-Type:application/json&apos; \<br />
-                        <span className="me-2"></span> -d&apos;
-                        {JSON.stringify(this.state.deployment)}&apos;
-                      </code>
-                    </pre>
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
+          <Header
+            apiDocs="https://docs.datacater.io/docs/api/deployments/"
+            apiPath="/deployments/"
+            httpMethod="POST"
+            requestBody={this.state.deployment}
+            title="Create new deployment"
+            subTitle="Deployments operate Pipelines."
+          />
           <form>
             <div className="col-12 mt-4">
               <label htmlFor="name" className="form-label">

--- a/ui/src/containers/deployments/ShowDeployment.js
+++ b/ui/src/containers/deployments/ShowDeployment.js
@@ -1,34 +1,24 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { Copy, Trash2 } from "react-feather";
+import { Trash2 } from "react-feather";
 import { Redirect } from "react-router-dom";
 import * as YAML from "json-to-pretty-yaml";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import Breadcrumb from "../../components/layout/Breadcrumb";
-import { getApiPathPrefix } from "../../helpers/getApiPathPrefix";
+import Header from "../../components/layout/Header";
 import { deleteDeployment, fetchDeployment } from "../../actions/deployments";
 
 class ShowDeployment extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      showApiCall: false,
       deploymentDeleted: false,
     };
-    this.toggleShowApiCall = this.toggleShowApiCall.bind(this);
     this.handleDelete = this.handleDelete.bind(this);
   }
 
   componentDidMount() {
     this.props.fetchDeployment(this.getDeploymentId());
-  }
-
-  toggleShowApiCall(event) {
-    event.preventDefault();
-
-    this.setState({
-      showApiCall: !this.state.showApiCall,
-    });
   }
 
   getDeploymentId() {
@@ -80,92 +70,34 @@ class ShowDeployment extends Component {
               { name: deployment.uuid },
             ]}
           />
-          <div className="col-12 mt-3">
-            <div
-              className="card welcome-card py-2"
-              style={{ backgroundImage: "url(/images/bg-card.jpg)" }}
-            >
-              <div className="card-body text-center p-0">
-                <div className="row justify-content-center">
-                  <div className="col-6 text-start d-flex align-items-center">
-                    <h4 className="fw-semibold mb-0">
-                      {deployment.name || "Untitled deployment"}
-                    </h4>
-                  </div>
-                  <div className="col-6 d-flex align-items-center justify-content-end">
-                    <div>
-                      <a
-                        href="/deployments"
-                        className="btn btn-light btn-pill"
-                        onClick={this.toggleShowApiCall}
-                      >
-                        {this.state.showApiCall ? "Hide" : "Show"} API call
-                      </a>
-                      <a
-                        href={`/deployments/${deployment.uuid}/edit`}
-                        className="btn btn-primary text-white ms-2"
-                      >
-                        Edit
-                      </a>
-                      <a
-                        href={`/deployments/${deployment.uuid}/logs`}
-                        className="btn btn-light ms-2"
-                      >
-                        Logs
-                      </a>
-                      <a
-                        href={`/deployments/${deployment.uuid}`}
-                        onClick={this.handleDelete}
-                        className="btn btn-light btn-outline-danger ms-2"
-                      >
-                        <Trash2 className="feather-icon" />
-                      </a>
-                    </div>
-                  </div>
-                </div>
-                {this.state.showApiCall && (
-                  <div className="bg-black mx-n3 p-3 mt-3 mb-n3 text-start">
-                    <pre className="mb-0">
-                      <a
-                        href="https://docs.datacater.io/docs/api/deployments/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="btn btn-sm btn-light float-end"
-                      >
-                        See docs
-                      </a>
-                      <a
-                        href="/deployments/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="btn btn-sm btn-light me-2 float-end"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          navigator.clipboard.writeText(
-                            "curl " +
-                              getApiPathPrefix(true) +
-                              "/deployments/" +
-                              deployment.uuid +
-                              " -H'Authorization:Bearer YOUR_TOKEN'"
-                          );
-                        }}
-                      >
-                        <Copy className="feather-icon" />
-                      </a>
-                      <code className="text-white">
-                        $ curl {getApiPathPrefix(true)}/deployments/
-                        {deployment.uuid} \
-                        <br />
-                        <span className="me-2"></span>{" "}
-                        -H&apos;Authorization:Bearer YOUR_TOKEN&apos;
-                        <br />
-                      </code>
-                    </pre>
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
+          <Header
+            apiDocs="https://docs.datacater.io/docs/api/deployments/"
+            apiPath={`/deployments/${deployment.uuid}`}
+            buttons={
+              <>
+                <a
+                  href={`/deployments/${deployment.uuid}/edit`}
+                  className="btn btn-primary text-white ms-2"
+                >
+                  Edit
+                </a>
+                <a
+                  href={`/deployments/${deployment.uuid}/logs`}
+                  className="btn btn-light ms-2"
+                >
+                  Logs
+                </a>
+                <a
+                  href={`/deployments/${deployment.uuid}`}
+                  onClick={this.handleDelete}
+                  className="btn btn-light btn-outline-danger ms-2"
+                >
+                  <Trash2 className="feather-icon" />
+                </a>
+              </>
+            }
+            title={deployment.name || "Untitled deployment"}
+          />
         </div>
         <div className="row mt-4">
           <div className="col-12">

--- a/ui/src/containers/pipelines/ListPipelines.js
+++ b/ui/src/containers/pipelines/ListPipelines.js
@@ -1,29 +1,12 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { Copy } from "react-feather";
 import Breadcrumb from "../../components/layout/Breadcrumb";
+import Header from "../../components/layout/Header";
 import { fetchPipelines } from "../../actions/pipelines";
-import { getApiPathPrefix } from "../../helpers/getApiPathPrefix";
 
 class ListPipelines extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      showApiCall: false,
-    };
-    this.toggleShowApiCall = this.toggleShowApiCall.bind(this);
-  }
-
   componentDidMount() {
     this.props.fetchPipelines();
-  }
-
-  toggleShowApiCall(event) {
-    event.preventDefault();
-
-    this.setState({
-      showApiCall: !this.state.showApiCall,
-    });
   }
 
   render() {
@@ -46,79 +29,24 @@ class ListPipelines extends Component {
       <div className="container">
         <div className="row">
           <Breadcrumb items={[{ name: "Pipelines" }]} />
-          <div className="col-12 mt-3">
-            <div
-              className="card welcome-card py-2"
-              style={{ backgroundImage: "url(/images/bg-card.jpg)" }}
-            >
-              <div className="card-body text-center p-0">
-                <div className="row justify-content-center">
-                  <div className="col-8 text-start">
-                    <h4 className="fw-semibold mb-0">Pipelines</h4>
-                    <p className="text-white mb-0">
-                      Pipelines stream records between your Streams and can
-                      apply filters and transforms on the way.
-                    </p>
-                  </div>
-                  <div className="col-4 d-flex align-items-center justify-content-end">
-                    <div>
-                      <a
-                        href="/pipelines"
-                        className="btn btn-light btn-pill"
-                        onClick={this.toggleShowApiCall}
-                      >
-                        {this.state.showApiCall ? "Hide" : "Show"} API call
-                      </a>
-                      {pipelines.length > 0 && (
-                        <a
-                          href="/pipelines/new"
-                          className="btn btn-primary text-white ms-2"
-                        >
-                          Create new pipeline
-                        </a>
-                      )}
-                    </div>
-                  </div>
-                </div>
-                {this.state.showApiCall && (
-                  <div className="bg-black mx-n3 p-3 mt-3 mb-n3 text-start">
-                    <pre className="mb-0">
-                      <a
-                        href="https://docs.datacater.io/docs/api/pipelines/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="btn btn-sm btn-light float-end"
-                      >
-                        See docs
-                      </a>
-                      <a
-                        href="/pipelines/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="btn btn-sm btn-light me-2 float-end"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          navigator.clipboard.writeText(
-                            "curl " +
-                              getApiPathPrefix(true) +
-                              "/pipelines -H'Authorization:Bearer YOUR_TOKEN'"
-                          );
-                        }}
-                      >
-                        <Copy className="feather-icon" />
-                      </a>
-                      <code className="text-white">
-                        $ curl {getApiPathPrefix(true)}/pipelines/ \<br />
-                        <span className="me-2"></span>{" "}
-                        -H&apos;Authorization:Bearer YOUR_TOKEN&apos;
-                        <br />
-                      </code>
-                    </pre>
-                  </div>
+          <Header
+            apiDocs="https://docs.datacater.io/docs/api/pipelines/"
+            apiPath="/pipelines/"
+            buttons={
+              <>
+                {pipelines.length > 0 && (
+                  <a
+                    href="/pipelines/new"
+                    className="btn btn-primary text-white ms-2"
+                  >
+                    Create new pipeline
+                  </a>
                 )}
-              </div>
-            </div>
-          </div>
+              </>
+            }
+            title="Pipelines"
+            subTitle="Pipelines stream records between your Streams and can apply filters and transforms on the way."
+          />
         </div>
         <div className="row mt-4">
           <div className="col-12">

--- a/ui/src/containers/pipelines/NewPipeline.js
+++ b/ui/src/containers/pipelines/NewPipeline.js
@@ -2,11 +2,10 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { Redirect } from "react-router-dom";
 import Select from "react-select";
-import { Copy } from "react-feather";
 import Breadcrumb from "../../components/layout/Breadcrumb";
+import Header from "../../components/layout/Header";
 import { addPipeline } from "../../actions/pipelines";
 import { fetchStreams } from "../../actions/streams";
-import { getApiPathPrefix } from "../../helpers/getApiPathPrefix";
 import "../../scss/fonts.scss";
 
 class NewPipeline extends Component {
@@ -16,7 +15,6 @@ class NewPipeline extends Component {
     this.state = {
       creatingPipelineFailed: false,
       errorMessages: {},
-      showApiCall: false,
       pipeline: {
         metadata: {},
         spec: {},
@@ -26,7 +24,6 @@ class NewPipeline extends Component {
 
     this.handleCreatePipeline = this.handleCreatePipeline.bind(this);
     this.handleChange = this.handleChange.bind(this);
-    this.toggleShowApiCall = this.toggleShowApiCall.bind(this);
   }
 
   componentDidMount() {
@@ -67,14 +64,6 @@ class NewPipeline extends Component {
     });
   }
 
-  toggleShowApiCall(event) {
-    event.preventDefault();
-
-    this.setState({
-      showApiCall: !this.state.showApiCall,
-    });
-  }
-
   render() {
     if (this.state.pipelineCreated) {
       return (
@@ -98,75 +87,14 @@ class NewPipeline extends Component {
               { name: "New pipeline" },
             ]}
           />
-          <div className="col-12 mt-3">
-            <div
-              className="card welcome-card py-2"
-              style={{ backgroundImage: "url(/images/bg-card.jpg)" }}
-            >
-              <div className="card-body text-center p-0">
-                <div className="row justify-content-center">
-                  <div className="col-10 text-start">
-                    <h4 className="fw-semibold mb-0">Create new pipeline</h4>
-                    <p className="text-white mb-0">
-                      Pipelines stream records between your Streams and can
-                      apply filters and transforms on the way.
-                    </p>
-                  </div>
-                  <div className="col-2 d-flex align-items-center justify-content-end">
-                    <a
-                      href="/pipelines/new"
-                      className="btn btn-light btn-pill"
-                      onClick={this.toggleShowApiCall}
-                    >
-                      {this.state.showApiCall ? "Hide" : "Show"} API call
-                    </a>
-                  </div>
-                </div>
-                {this.state.showApiCall && (
-                  <div className="bg-black mx-n3 p-3 mt-3 mb-n3 text-start">
-                    <pre className="mb-0">
-                      <a
-                        href="https://docs.datacater.io/docs/api/pipelines/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="btn btn-sm btn-light float-end"
-                      >
-                        See docs
-                      </a>
-                      <a
-                        href="/pipelines/new/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="btn btn-sm btn-light me-2 float-end"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          navigator.clipboard.writeText(
-                            "curl " +
-                              getApiPathPrefix(true) +
-                              "/pipelines -XPOST -H'Content-Type:application/json' -H'Authorization:Bearer YOUR_TOKEN' -d'" +
-                              JSON.stringify(this.state.pipeline) +
-                              "'"
-                          );
-                        }}
-                      >
-                        <Copy className="feather-icon" />
-                      </a>
-                      <code className="text-white">
-                        $ curl {getApiPathPrefix(true)}/pipelines/ \<br />
-                        <span className="me-2"></span> -XPOST \<br />
-                        <span className="me-2"></span>{" "}
-                        -H&apos;Authorization:Bearer YOUR_TOKEN&apos; \<br />
-                        <span className="me-2"></span>{" "}
-                        -H&apos;Content-Type:application/json&apos; \<br />
-                        <span className="me-2"></span> -d&apos;
-                        {JSON.stringify(this.state.pipeline)}&apos;
-                      </code>
-                    </pre>
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
+          <Header
+            apiDocs="https://docs.datacater.io/docs/api/pipelines/"
+            apiPath="/pipelines/"
+            httpMethod="POST"
+            requestBody={this.state.pipeline}
+            title="Create new pipeline"
+            subTitle="Pipelines stream records between your Streams and can apply filters and transforms on the way."
+          />
           <form>
             <div className="col-12 mt-4">
               <label htmlFor="name" className="form-label">

--- a/ui/src/containers/pipelines/PipelineSettings.js
+++ b/ui/src/containers/pipelines/PipelineSettings.js
@@ -1,12 +1,11 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { Redirect } from "react-router-dom";
-import { Copy } from "react-feather";
 import Select from "react-select";
 import Breadcrumb from "../../components/layout/Breadcrumb";
+import Header from "../../components/layout/Header";
 import { fetchPipeline, updatePipeline } from "../../actions/pipelines";
 import { fetchStreams } from "../../actions/streams";
-import { getApiPathPrefix } from "../../helpers/getApiPathPrefix";
 import "../../scss/fonts.scss";
 
 class PipelineSettings extends Component {
@@ -16,14 +15,12 @@ class PipelineSettings extends Component {
     this.state = {
       updatingPipelineFailed: false,
       errorMessages: {},
-      showApiCall: false,
       pipeline: undefined,
       pipelineUpdated: false,
     };
 
     this.handleUpdatePipeline = this.handleUpdatePipeline.bind(this);
     this.handleChange = this.handleChange.bind(this);
-    this.toggleShowApiCall = this.toggleShowApiCall.bind(this);
   }
 
   componentDidMount() {
@@ -73,14 +70,6 @@ class PipelineSettings extends Component {
     });
   }
 
-  toggleShowApiCall(event) {
-    event.preventDefault();
-
-    this.setState({
-      showApiCall: !this.state.showApiCall,
-    });
-  }
-
   render() {
     if (this.state.pipelineUpdated) {
       return <Redirect to={`/pipelines/${this.getPipelineId()}`} />;
@@ -112,77 +101,13 @@ class PipelineSettings extends Component {
               { name: "Settings" },
             ]}
           />
-          <div className="col-12 mt-3">
-            <div
-              className="card welcome-card py-2"
-              style={{ backgroundImage: "url(/images/bg-card.jpg)" }}
-            >
-              <div className="card-body text-center p-0">
-                <div className="row justify-content-center align-items-center">
-                  <div className="col-10 text-start">
-                    <h4 className="fw-semibold mb-0">
-                      {pipeline.name || "Untitled pipeline"}
-                    </h4>
-                  </div>
-                  <div className="col-2 d-flex align-items-center justify-content-end">
-                    <a
-                      href="/pipelines/edit"
-                      className="btn btn-light btn-pill"
-                      onClick={this.toggleShowApiCall}
-                    >
-                      {this.state.showApiCall ? "Hide" : "Show"} API call
-                    </a>
-                  </div>
-                </div>
-                {this.state.showApiCall && (
-                  <div className="bg-black mx-n3 p-3 mt-3 mb-n3 text-start">
-                    <pre className="mb-0">
-                      <a
-                        href="https://docs.datacater.io/docs/api/pipelines/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="btn btn-sm btn-light float-end"
-                      >
-                        See docs
-                      </a>
-                      <a
-                        href="/pipelines/new/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="btn btn-sm btn-light me-2 float-end"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          navigator.clipboard.writeText(
-                            "curl " +
-                              getApiPathPrefix(true) +
-                              "/pipelines/" +
-                              pipeline.uuid +
-                              " -XPUT -H'Content-Type:application/json' -H'Authorization:Bearer YOUR_TOKEN' -d'" +
-                              JSON.stringify(apiPayload) +
-                              "'"
-                          );
-                        }}
-                      >
-                        <Copy className="feather-icon" />
-                      </a>
-                      <code className="text-white">
-                        $ curl {getApiPathPrefix(true)}/pipelines/
-                        {pipeline.uuid} \
-                        <br />
-                        <span className="me-2"></span> -XPUT \<br />
-                        <span className="me-2"></span>{" "}
-                        -H&apos;Authorization:Bearer YOUR_TOKEN&apos; \<br />
-                        <span className="me-2"></span>{" "}
-                        -H&apos;Content-Type:application/json&apos; \<br />
-                        <span className="me-2"></span> -d&apos;
-                        {JSON.stringify(apiPayload)}&apos;
-                      </code>
-                    </pre>
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
+          <Header
+            apiDocs="https://docs.datacater.io/docs/api/pipelines/"
+            apiPath={`/pipelines/${pipeline.uuid}`}
+            httpMethod="PUT"
+            requestBody={apiPayload}
+            title={pipeline.name || "Untitled pipeline"}
+          />
           <form>
             <div className="col-12 mt-4">
               <label htmlFor="name" className="form-label">

--- a/ui/src/containers/pipelines/ShowPipeline.js
+++ b/ui/src/containers/pipelines/ShowPipeline.js
@@ -1,34 +1,24 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { Copy, Settings, Trash2 } from "react-feather";
+import { Settings, Trash2 } from "react-feather";
 import { Redirect } from "react-router-dom";
 import * as YAML from "json-to-pretty-yaml";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import Breadcrumb from "../../components/layout/Breadcrumb";
-import { getApiPathPrefix } from "../../helpers/getApiPathPrefix";
+import Header from "../../components/layout/Header";
 import { deletePipeline, fetchPipeline } from "../../actions/pipelines";
 
 class ShowPipeline extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      showApiCall: false,
       pipelineDeleted: false,
     };
-    this.toggleShowApiCall = this.toggleShowApiCall.bind(this);
     this.handleDelete = this.handleDelete.bind(this);
   }
 
   componentDidMount() {
     this.props.fetchPipeline(this.getPipelineId());
-  }
-
-  toggleShowApiCall(event) {
-    event.preventDefault();
-
-    this.setState({
-      showApiCall: !this.state.showApiCall,
-    });
   }
 
   getPipelineId() {
@@ -78,90 +68,34 @@ class ShowPipeline extends Component {
               { name: pipeline.uuid },
             ]}
           />
-          <div className="col-12 mt-3">
-            <div
-              className="card welcome-card py-2"
-              style={{ backgroundImage: "url(/images/bg-card.jpg)" }}
-            >
-              <div className="card-body text-center p-0">
-                <div className="row justify-content-center">
-                  <div className="col-6 text-start d-flex align-items-center">
-                    <h4 className="fw-semibold mb-0">{pipeline.name}</h4>
-                  </div>
-                  <div className="col-6 d-flex align-items-center justify-content-end">
-                    <div>
-                      <a
-                        href="/pipelines"
-                        className="btn btn-light btn-pill"
-                        onClick={this.toggleShowApiCall}
-                      >
-                        {this.state.showApiCall ? "Hide" : "Show"} API call
-                      </a>
-                      <a
-                        href={`/pipelines/${pipeline.uuid}/edit`}
-                        className="btn btn-primary text-white ms-2"
-                      >
-                        Edit in Pipeline Designer
-                      </a>
-                      <a
-                        href={`/pipelines/${pipeline.uuid}/settings`}
-                        className="btn btn-light ms-2"
-                      >
-                        <Settings className="feather-icon" />
-                      </a>
-                      <a
-                        href={`/pipelines/${pipeline.uuid}`}
-                        onClick={this.handleDelete}
-                        className="btn btn-light btn-outline-danger ms-2"
-                      >
-                        <Trash2 className="feather-icon" />
-                      </a>
-                    </div>
-                  </div>
-                </div>
-                {this.state.showApiCall && (
-                  <div className="bg-black mx-n3 p-3 mt-3 mb-n3 text-start">
-                    <pre className="mb-0">
-                      <a
-                        href="https://docs.datacater.io/docs/api/pipelines/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="btn btn-sm btn-light float-end"
-                      >
-                        See docs
-                      </a>
-                      <a
-                        href="/pipelines/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="btn btn-sm btn-light me-2 float-end"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          navigator.clipboard.writeText(
-                            "curl " +
-                              getApiPathPrefix(true) +
-                              "/pipelines/" +
-                              pipeline.uuid +
-                              " -H'Authorization:Bearer YOUR_TOKEN'"
-                          );
-                        }}
-                      >
-                        <Copy className="feather-icon" />
-                      </a>
-                      <code className="text-white">
-                        $ curl {getApiPathPrefix(true)}/pipelines/
-                        {pipeline.uuid} \
-                        <br />
-                        <span className="me-2"></span>{" "}
-                        -H&apos;Authorization:Bearer YOUR_TOKEN&apos;
-                        <br />
-                      </code>
-                    </pre>
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
+          <Header
+            apiDocs="https://docs.datacater.io/docs/api/pipelines/"
+            apiPath={`/pipelines/${pipeline.uuid}`}
+            buttons={
+              <>
+                <a
+                  href={`/pipelines/${pipeline.uuid}/edit`}
+                  className="btn btn-primary text-white ms-2"
+                >
+                  Edit in Pipeline Designer
+                </a>
+                <a
+                  href={`/pipelines/${pipeline.uuid}/settings`}
+                  className="btn btn-light ms-2"
+                >
+                  <Settings className="feather-icon" />
+                </a>
+                <a
+                  href={`/pipelines/${pipeline.uuid}`}
+                  onClick={this.handleDelete}
+                  className="btn btn-light btn-outline-danger ms-2"
+                >
+                  <Trash2 className="feather-icon" />
+                </a>
+              </>
+            }
+            title={pipeline.name || "Untitled pipeline"}
+          />
         </div>
         <div className="row mt-4">
           <div className="col-12">

--- a/ui/src/containers/streams/EditStream.js
+++ b/ui/src/containers/streams/EditStream.js
@@ -2,10 +2,9 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { Redirect } from "react-router-dom";
 import Creatable from "react-select/creatable";
-import { Copy } from "react-feather";
 import Breadcrumb from "../../components/layout/Breadcrumb";
+import Header from "../../components/layout/Header";
 import { fetchStream, updateStream } from "../../actions/streams";
-import { getApiPathPrefix } from "../../helpers/getApiPathPrefix";
 import { getStreamConnectionOptions } from "../../helpers/getStreamConnectionOptions";
 import { getStreamTopicOptions } from "../../helpers/getStreamTopicOptions";
 import { getDeserializerOptions } from "../../helpers/getDeserializerOptions";
@@ -20,7 +19,6 @@ class EditStream extends Component {
     this.state = {
       updatingStreamFailed: false,
       errorMessages: {},
-      showApiCall: false,
       showTopicConfig: false,
       stream: undefined,
       tempConfig: {
@@ -34,7 +32,6 @@ class EditStream extends Component {
 
     this.handleUpdateStream = this.handleUpdateStream.bind(this);
     this.handleChange = this.handleChange.bind(this);
-    this.toggleShowApiCall = this.toggleShowApiCall.bind(this);
     this.toggleShowTopicConfig = this.toggleShowTopicConfig.bind(this);
     this.updateTempConfig = this.updateTempConfig.bind(this);
     this.updateConnectionConfig = this.updateConnectionConfig.bind(this);
@@ -150,14 +147,6 @@ class EditStream extends Component {
     });
   }
 
-  toggleShowApiCall(event) {
-    event.preventDefault();
-
-    this.setState({
-      showApiCall: !this.state.showApiCall,
-    });
-  }
-
   toggleShowTopicConfig(event) {
     event.preventDefault();
 
@@ -216,76 +205,13 @@ class EditStream extends Component {
               { name: "Edit" },
             ]}
           />
-          <div className="col-12 mt-3">
-            <div
-              className="card welcome-card py-2"
-              style={{ backgroundImage: "url(/images/bg-card.jpg)" }}
-            >
-              <div className="card-body text-center p-0">
-                <div className="row justify-content-center align-items-center">
-                  <div className="col-10 text-start">
-                    <h4 className="fw-semibold mb-0">
-                      {stream.name || "Untitled stream"}
-                    </h4>
-                  </div>
-                  <div className="col-2 d-flex align-items-center justify-content-end">
-                    <a
-                      href="/streams/new"
-                      className="btn btn-light btn-pill"
-                      onClick={this.toggleShowApiCall}
-                    >
-                      {this.state.showApiCall ? "Hide" : "Show"} API call
-                    </a>
-                  </div>
-                </div>
-                {this.state.showApiCall && (
-                  <div className="bg-black mx-n3 p-3 mt-3 mb-n3 text-start">
-                    <pre className="mb-0">
-                      <a
-                        href="https://docs.datacater.io/docs/api/streams/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="btn btn-sm btn-light float-end"
-                      >
-                        See docs
-                      </a>
-                      <a
-                        href="/streams/new/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="btn btn-sm btn-light me-2 float-end"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          navigator.clipboard.writeText(
-                            "curl " +
-                              getApiPathPrefix(true) +
-                              "/streams/" +
-                              stream.uuid +
-                              " -XPUT -H'Content-Type:application/json' -H'Authorization:Bearer YOUR_TOKEN' -d'" +
-                              JSON.stringify(apiPayload) +
-                              "'"
-                          );
-                        }}
-                      >
-                        <Copy className="feather-icon" />
-                      </a>
-                      <code className="text-white">
-                        $ curl {getApiPathPrefix(true)}/streams/{stream.uuid} \
-                        <br />
-                        <span className="me-2"></span> -XPUT \<br />
-                        <span className="me-2"></span>{" "}
-                        -H&apos;Authorization:Bearer YOUR_TOKEN&apos; \<br />
-                        <span className="me-2"></span>{" "}
-                        -H&apos;Content-Type:application/json&apos; \<br />
-                        <span className="me-2"></span> -d&apos;
-                        {JSON.stringify(apiPayload)}&apos;
-                      </code>
-                    </pre>
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
+          <Header
+            apiDocs="https://docs.datacater.io/docs/api/streams/"
+            apiPath={`/streams/${stream.uuid}`}
+            httpMethod="PUT"
+            requestBody={apiPayload}
+            title={stream.name || "Untitled stream"}
+          />
           <form>
             <div className="col-12 mt-4">
               <label htmlFor="name" className="form-label">

--- a/ui/src/containers/streams/InspectStream.js
+++ b/ui/src/containers/streams/InspectStream.js
@@ -3,7 +3,6 @@ import { connect } from "react-redux";
 import {
   Check,
   Code,
-  Copy,
   Hash,
   HelpCircle,
   List,
@@ -15,7 +14,7 @@ import { fetchStream, inspectStream } from "../../actions/streams";
 import { profileRecords } from "../../helpers/profileRecords";
 import TableHeaderCell from "../../components/streams/TableHeaderCell";
 import Breadcrumb from "../../components/layout/Breadcrumb";
-import { getApiPathPrefix } from "../../helpers/getApiPathPrefix";
+import Header from "../../components/layout/Header";
 import { renderTableCellContent } from "../../helpers/renderTableCellContent";
 import "../../scss/grid.scss";
 import "../../scss/grid/statistics.scss";
@@ -28,10 +27,10 @@ class InspectStream extends Component {
       showApiCall: false,
       showGrid: true,
     };
-    this.toggleShowApiCall = this.toggleShowApiCall.bind(this);
     this.toggleShowGrid = this.toggleShowGrid.bind(this);
     this.getColumns = this.getColumns.bind(this);
     this.updateInspectLimit = this.updateInspectLimit.bind(this);
+    this.updateShowApiCall = this.updateShowApiCall.bind(this);
   }
 
   getColumns(profile) {
@@ -119,11 +118,9 @@ class InspectStream extends Component {
     this.props.inspectStream(this.getStreamId(), limit);
   }
 
-  toggleShowApiCall(event) {
-    event.preventDefault();
-
+  updateShowApiCall(showApiCall) {
     this.setState({
-      showApiCall: !this.state.showApiCall,
+      showApiCall: showApiCall,
     });
   }
 
@@ -187,75 +184,12 @@ class InspectStream extends Component {
             { name: "Inspect" },
           ]}
         />
-        <div className="col-12 mt-3">
-          <div
-            className="card welcome-card py-2"
-            style={{ backgroundImage: "url(/images/bg-card.jpg)" }}
-          >
-            <div className="card-body text-center p-0">
-              <div className="row justify-content-center">
-                <div className="col-6 text-start d-flex align-items-center">
-                  <h4 className="fw-semibold mb-0">
-                    {stream.name || "Untitled pipeline"}
-                  </h4>
-                </div>
-                <div className="col-6 d-flex align-items-center justify-content-end">
-                  <div>
-                    <a
-                      href="/streams"
-                      className="btn btn-light btn-pill"
-                      onClick={this.toggleShowApiCall}
-                    >
-                      {this.state.showApiCall ? "Hide" : "Show"} API call
-                    </a>
-                  </div>
-                </div>
-              </div>
-              {this.state.showApiCall && (
-                <div className="bg-black mx-n3 p-3 mt-3 mb-n3 text-start">
-                  <pre className="mb-0">
-                    <a
-                      href="https://docs.datacater.io/docs/api/streams/"
-                      target="_blank"
-                      rel="noreferrer"
-                      className="btn btn-sm btn-light float-end"
-                    >
-                      See docs
-                    </a>
-                    <a
-                      href="/streams/"
-                      target="_blank"
-                      rel="noreferrer"
-                      className="btn btn-sm btn-light me-2 float-end"
-                      onClick={(e) => {
-                        e.preventDefault();
-                        navigator.clipboard.writeText(
-                          "curl " +
-                            getApiPathPrefix(true) +
-                            "/streams/" +
-                            stream.uuid +
-                            "/inspect?limit=" +
-                            this.state.inspectLimit +
-                            " -H'Authorization:Bearer YOUR_TOKEN'"
-                        );
-                      }}
-                    >
-                      <Copy className="feather-icon" />
-                    </a>
-                    <code className="text-white">
-                      $ curl {getApiPathPrefix(true)}/streams/{stream.uuid}
-                      /inspect?limit=
-                      {this.state.inspectLimit} \<br />
-                      <span className="me-2"></span>{" "}
-                      -H&apos;Authorization:Bearer YOUR_TOKEN&apos;
-                      <br />
-                    </code>
-                  </pre>
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
+        <Header
+          apiDocs="https://docs.datacater.io/docs/api/streams/"
+          apiPath={`/streams/${stream.uuid}/inspect?limit=${this.state.inspectLimit}`}
+          title={stream.name || "Untitled stream"}
+          updateCallback={this.updateShowApiCall}
+        />
       </div>
     );
 

--- a/ui/src/containers/streams/ListStreams.js
+++ b/ui/src/containers/streams/ListStreams.js
@@ -1,29 +1,12 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { Copy } from "react-feather";
 import Breadcrumb from "../../components/layout/Breadcrumb";
-import { getApiPathPrefix } from "../../helpers/getApiPathPrefix";
+import Header from "../../components/layout/Header";
 import { fetchStreams } from "../../actions/streams";
 
 class ListStreams extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      showApiCall: false,
-    };
-    this.toggleShowApiCall = this.toggleShowApiCall.bind(this);
-  }
-
   componentDidMount() {
     this.props.fetchStreams();
-  }
-
-  toggleShowApiCall(event) {
-    event.preventDefault();
-
-    this.setState({
-      showApiCall: !this.state.showApiCall,
-    });
   }
 
   render() {
@@ -46,78 +29,24 @@ class ListStreams extends Component {
       <div className="container">
         <div className="row">
           <Breadcrumb items={[{ name: "Streams" }]} />
-          <div className="col-12 mt-3">
-            <div
-              className="card welcome-card py-2"
-              style={{ backgroundImage: "url(/images/bg-card.jpg)" }}
-            >
-              <div className="card-body text-center p-0">
-                <div className="row justify-content-center">
-                  <div className="col-8 text-start">
-                    <h4 className="fw-semibold mb-0">Streams</h4>
-                    <p className="text-white mb-0">
-                      Streams connect Apache Kafka® topics with your pipeline.
-                    </p>
-                  </div>
-                  <div className="col-4 d-flex align-items-center justify-content-end">
-                    <div>
-                      <a
-                        href="/streams"
-                        className="btn btn-light btn-pill"
-                        onClick={this.toggleShowApiCall}
-                      >
-                        {this.state.showApiCall ? "Hide" : "Show"} API call
-                      </a>
-                      {streams.length > 0 && (
-                        <a
-                          href="/streams/new"
-                          className="btn btn-primary text-white ms-2"
-                        >
-                          Create new stream
-                        </a>
-                      )}
-                    </div>
-                  </div>
-                </div>
-                {this.state.showApiCall && (
-                  <div className="bg-black mx-n3 p-3 mt-3 mb-n3 text-start">
-                    <pre className="mb-0">
-                      <a
-                        href="https://docs.datacater.io/docs/api/streams/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="btn btn-sm btn-light float-end"
-                      >
-                        See docs
-                      </a>
-                      <a
-                        href="/streams/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="btn btn-sm btn-light me-2 float-end"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          navigator.clipboard.writeText(
-                            "curl " +
-                              getApiPathPrefix(true) +
-                              "/streams -H'Authorization:Bearer YOUR_TOKEN'"
-                          );
-                        }}
-                      >
-                        <Copy className="feather-icon" />
-                      </a>
-                      <code className="text-white">
-                        $ curl {getApiPathPrefix(true)}/streams/ \<br />
-                        <span className="me-2"></span>{" "}
-                        -H&apos;Authorization:Bearer YOUR_TOKEN&apos;
-                        <br />
-                      </code>
-                    </pre>
-                  </div>
+          <Header
+            apiDocs="https://docs.datacater.io/docs/api/streams/"
+            apiPath="/streams/"
+            buttons={
+              <>
+                {streams.length > 0 && (
+                  <a
+                    href="/streams/new"
+                    className="btn btn-primary text-white ms-2"
+                  >
+                    Create new stream
+                  </a>
                 )}
-              </div>
-            </div>
-          </div>
+              </>
+            }
+            title="Streams"
+            subTitle="Streams connect Apache Kafka® topics with your pipeline."
+          />
         </div>
         <div className="row mt-4">
           <div className="col-12">

--- a/ui/src/containers/streams/NewStream.js
+++ b/ui/src/containers/streams/NewStream.js
@@ -2,10 +2,9 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { Redirect } from "react-router-dom";
 import Creatable from "react-select/creatable";
-import { Copy } from "react-feather";
 import Breadcrumb from "../../components/layout/Breadcrumb";
+import Header from "../../components/layout/Header";
 import { addStream } from "../../actions/streams";
-import { getApiPathPrefix } from "../../helpers/getApiPathPrefix";
 import { getStreamConnectionOptions } from "../../helpers/getStreamConnectionOptions";
 import { getStreamTopicOptions } from "../../helpers/getStreamTopicOptions";
 import { getDeserializerOptions } from "../../helpers/getDeserializerOptions";
@@ -20,7 +19,6 @@ class NewStream extends Component {
     this.state = {
       creatingStreamFailed: false,
       errorMessages: {},
-      showApiCall: false,
       showTopicConfig: false,
       stream: {
         spec: {
@@ -43,7 +41,6 @@ class NewStream extends Component {
 
     this.handleCreateStream = this.handleCreateStream.bind(this);
     this.handleChange = this.handleChange.bind(this);
-    this.toggleShowApiCall = this.toggleShowApiCall.bind(this);
     this.toggleShowTopicConfig = this.toggleShowTopicConfig.bind(this);
     this.updateTempConfig = this.updateTempConfig.bind(this);
     this.updateConnectionConfig = this.updateConnectionConfig.bind(this);
@@ -149,14 +146,6 @@ class NewStream extends Component {
     });
   }
 
-  toggleShowApiCall(event) {
-    event.preventDefault();
-
-    this.setState({
-      showApiCall: !this.state.showApiCall,
-    });
-  }
-
   toggleShowTopicConfig(event) {
     event.preventDefault();
 
@@ -205,74 +194,14 @@ class NewStream extends Component {
               { name: "New stream" },
             ]}
           />
-          <div className="col-12 mt-3">
-            <div
-              className="card welcome-card py-2"
-              style={{ backgroundImage: "url(/images/bg-card.jpg)" }}
-            >
-              <div className="card-body text-center p-0">
-                <div className="row justify-content-center">
-                  <div className="col-10 text-start">
-                    <h4 className="fw-semibold mb-0">Create new stream</h4>
-                    <p className="text-white mb-0">
-                      Streams connect Apache Kafka® topics with your pipeline.
-                    </p>
-                  </div>
-                  <div className="col-2 d-flex align-items-center justify-content-end">
-                    <a
-                      href="/streams/new"
-                      className="btn btn-light btn-pill"
-                      onClick={this.toggleShowApiCall}
-                    >
-                      {this.state.showApiCall ? "Hide" : "Show"} API call
-                    </a>
-                  </div>
-                </div>
-                {this.state.showApiCall && (
-                  <div className="bg-black mx-n3 p-3 mt-3 mb-n3 text-start">
-                    <pre className="mb-0">
-                      <a
-                        href="https://docs.datacater.io/docs/api/streams/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="btn btn-sm btn-light float-end"
-                      >
-                        See docs
-                      </a>
-                      <a
-                        href="/streams/new/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="btn btn-sm btn-light me-2 float-end"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          navigator.clipboard.writeText(
-                            "curl " +
-                              getApiPathPrefix(true) +
-                              "/streams -XPOST -H'Content-Type:application/json' -H'Authorization:Bearer YOUR_TOKEN' -d'" +
-                              JSON.stringify(this.state.stream) +
-                              "'"
-                          );
-                        }}
-                      >
-                        <Copy className="feather-icon" />
-                      </a>
-                      <code className="text-white">
-                        $ curl {getApiPathPrefix(true)}/streams/ \<br />
-                        <span className="me-2"></span> -XPOST \<br />
-                        <span className="me-2"></span>{" "}
-                        -H&apos;Authorization:Bearer YOUR_TOKEN&apos; \<br />
-                        <span className="me-2"></span>{" "}
-                        -H&apos;Content-Type:application/json&apos; \<br />
-                        <span className="me-2"></span> -d&apos;
-                        {JSON.stringify(this.state.stream)}&apos;
-                      </code>
-                    </pre>
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
+          <Header
+            apiDocs="https://docs.datacater.io/docs/api/streams/"
+            apiPath="/streams/"
+            httpMethod="POST"
+            requestBody={this.state.stream}
+            title="Create new stream"
+            subTitle="Streams connect Apache Kafka® topics with your pipeline."
+          />
           <form>
             <div className="col-12 mt-4">
               <label htmlFor="name" className="form-label">

--- a/ui/src/containers/streams/ShowStream.js
+++ b/ui/src/containers/streams/ShowStream.js
@@ -1,34 +1,24 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { Copy, Trash2 } from "react-feather";
+import { Trash2 } from "react-feather";
 import { Redirect } from "react-router-dom";
 import * as YAML from "json-to-pretty-yaml";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import Breadcrumb from "../../components/layout/Breadcrumb";
-import { getApiPathPrefix } from "../../helpers/getApiPathPrefix";
+import Header from "../../components/layout/Header";
 import { deleteStream, fetchStream } from "../../actions/streams";
 
 class ShowStream extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      showApiCall: false,
       streamDeleted: false,
     };
-    this.toggleShowApiCall = this.toggleShowApiCall.bind(this);
     this.handleDelete = this.handleDelete.bind(this);
   }
 
   componentDidMount() {
     this.props.fetchStream(this.getStreamId());
-  }
-
-  toggleShowApiCall(event) {
-    event.preventDefault();
-
-    this.setState({
-      showApiCall: !this.state.showApiCall,
-    });
   }
 
   getStreamId() {
@@ -78,89 +68,34 @@ class ShowStream extends Component {
               { name: stream.uuid },
             ]}
           />
-          <div className="col-12 mt-3">
-            <div
-              className="card welcome-card py-2"
-              style={{ backgroundImage: "url(/images/bg-card.jpg)" }}
-            >
-              <div className="card-body text-center p-0">
-                <div className="row justify-content-center">
-                  <div className="col-6 text-start d-flex align-items-center">
-                    <h4 className="fw-semibold mb-0">{stream.name}</h4>
-                  </div>
-                  <div className="col-6 d-flex align-items-center justify-content-end">
-                    <div>
-                      <a
-                        href="/streams"
-                        className="btn btn-light btn-pill"
-                        onClick={this.toggleShowApiCall}
-                      >
-                        {this.state.showApiCall ? "Hide" : "Show"} API call
-                      </a>
-                      <a
-                        href={`/streams/${stream.uuid}/edit`}
-                        className="btn btn-primary text-white ms-2"
-                      >
-                        Edit
-                      </a>
-                      <a
-                        href={`/streams/${stream.uuid}/inspect`}
-                        className="btn btn-light ms-2"
-                      >
-                        Inspect
-                      </a>
-                      <a
-                        href={`/streams/${stream.uuid}`}
-                        onClick={this.handleDelete}
-                        className="btn btn-light btn-outline-danger ms-2"
-                      >
-                        <Trash2 className="feather-icon" />
-                      </a>
-                    </div>
-                  </div>
-                </div>
-                {this.state.showApiCall && (
-                  <div className="bg-black mx-n3 p-3 mt-3 mb-n3 text-start">
-                    <pre className="mb-0">
-                      <a
-                        href="https://docs.datacater.io/docs/api/streams/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="btn btn-sm btn-light float-end"
-                      >
-                        See docs
-                      </a>
-                      <a
-                        href="/streams/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="btn btn-sm btn-light me-2 float-end"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          navigator.clipboard.writeText(
-                            "curl " +
-                              getApiPathPrefix(true) +
-                              "/streams/" +
-                              stream.uuid +
-                              " -H'Authorization:Bearer YOUR_TOKEN'"
-                          );
-                        }}
-                      >
-                        <Copy className="feather-icon" />
-                      </a>
-                      <code className="text-white">
-                        $ curl {getApiPathPrefix(true)}/streams/{stream.uuid} \
-                        <br />
-                        <span className="me-2"></span>{" "}
-                        -H&apos;Authorization:Bearer YOUR_TOKEN&apos;
-                        <br />
-                      </code>
-                    </pre>
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
+          <Header
+            apiDocs="https://docs.datacater.io/docs/api/streams/"
+            apiPath={`/streams/${stream.uuid}`}
+            buttons={
+              <>
+                <a
+                  href={`/streams/${stream.uuid}/edit`}
+                  className="btn btn-primary text-white ms-2"
+                >
+                  Edit
+                </a>
+                <a
+                  href={`/streams/${stream.uuid}/inspect`}
+                  className="btn btn-light ms-2"
+                >
+                  Inspect
+                </a>
+                <a
+                  href={`/streams/${stream.uuid}`}
+                  onClick={this.handleDelete}
+                  className="btn btn-light btn-outline-danger ms-2"
+                >
+                  <Trash2 className="feather-icon" />
+                </a>
+              </>
+            }
+            title={stream.name || "Untitled stream"}
+          />
         </div>
         <div className="row mt-4">
           <div className="col-12">

--- a/ui/src/scss/main.scss
+++ b/ui/src/scss/main.scss
@@ -23,6 +23,18 @@ body {
   background-color: #f7fbf8;
 }
 
+.text-purple {
+  color: rgb(174, 117, 230);
+}
+
+.text-blue-light {
+  color: rgb(180, 210, 234);
+}
+
+.bg-gradient-purple {
+  background-image: linear-gradient(to right, #ae75e6, #b5e0ec);
+}
+
 .header-body {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;


### PR DESCRIPTION
This PR applies the following changes to our UI:

* Remove code duplicates and move the Header/API Call Widget to a separate ReactJS component, called `Header`, which is now used in most of our container components.
* Allow users to dynamically insert their authentication token into the generated `curl` commands, allowing them to copy the `curl` command and instantly use it. The token is already stored in the local storage of the browser and is valid for only a restricted time period, thus not creating an additional attack surface.