### PR TITLE
fix(ui): Correctly reset transforms

### DIFF
--- a/ui/src/containers/pipelines/EditPipeline.js
+++ b/ui/src/containers/pipelines/EditPipeline.js
@@ -257,7 +257,7 @@ class EditPipeline extends Component {
 
     if (step.kind === "Record") {
       if (property === "transform") {
-        if (value === undefined) {
+        if ([undefined, ""].includes(value)) {
           // Remove transform
           delete step.transform;
           pipeline.spec.steps[currentStep - 1] = step;
@@ -268,7 +268,7 @@ class EditPipeline extends Component {
           };
         }
       } else if (property === "filter") {
-        if (value === undefined) {
+        if ([undefined, ""].includes(value)) {
           // Remove filter
           delete step.filter;
           pipeline.spec.steps[currentStep - 1] = step;
@@ -295,9 +295,13 @@ class EditPipeline extends Component {
         );
       }
       if (property === "transform") {
-        if (value === undefined) {
+        if ([undefined, ""].includes(value)) {
           // Remove transform
           delete step.fields[fieldName].transform;
+          // Remove field if no filter is defined
+          if (Object.keys(step.fields[fieldName]).length === 0) {
+            delete step.fields[fieldName];
+          }
           pipeline.spec.steps[currentStep - 1] = step;
           editColumn = undefined;
         } else {
@@ -307,9 +311,13 @@ class EditPipeline extends Component {
             };
         }
       } else if (property === "filter") {
-        if (value === undefined) {
+        if ([undefined, ""].includes(value)) {
           // Remove filter
           delete step.fields[fieldName].filter;
+          // Remove field if no transform is defined
+          if (Object.keys(step.fields[fieldName]).length === 0) {
+            delete step.fields[fieldName];
+          }
           pipeline.spec.steps[currentStep - 1] = step;
           editColumn = undefined;
         } else {


### PR DESCRIPTION
When removing a transform in the UI-based pipeline designer, we previously set the transform key to an empty string, which produced pipeline YAMLs like the following one:

```yaml
spec:
  steps:
    fields:
      email:
        transform:
          key: "hash"
      name:
        transform:
          key: ""
```

These pipeline YAMLs failed when being evaluated with the Python runner since the runner could not find a transform with an empty key.

This commity changes this behavior and lets the pipeline designer correctly remove the transforms from the YAML, producing pipeline YAML that can be processed by the Python runner, e.g.:

```yaml
spec:
  steps:
    fields:
      email:
        transform:
          key: "hash"
```