### PR TITLE
feat(deployment): add consumer group to stream-in

### DIFF
--- a/platform-api/src/main/java/io/datacater/core/deployment/K8Deployment.java
+++ b/platform-api/src/main/java/io/datacater/core/deployment/K8Deployment.java
@@ -44,7 +44,8 @@ public class K8Deployment {
     k8NameSpace.create();
     k8ConfigMap.getOrCreate(configmapName, pe);
 
-    List<EnvVar> variables = getEnvironmentVariables(streamIn, streamOut, deploymentSpec);
+    List<EnvVar> variables =
+        getEnvironmentVariables(streamIn, streamOut, deploymentSpec, deploymentId);
 
     try {
       Deployment deployment =
@@ -256,7 +257,7 @@ public class K8Deployment {
   }
 
   private List<EnvVar> getEnvironmentVariables(
-      StreamEntity streamIn, StreamEntity streamOut, DeploymentSpec deploymentSpec) {
+      StreamEntity streamIn, StreamEntity streamOut, DeploymentSpec deploymentSpec, UUID uuid) {
     ObjectMapper objectMapper = new ObjectMapper();
     Map<String, Object> streamInConfig = nodeToMap(streamIn.getSpec().get(StaticConfig.KAFKA_TAG));
     Map<String, Object> streamOutConfig =
@@ -275,6 +276,7 @@ public class K8Deployment {
     streamInConfig.putIfAbsent(
         StaticConfig.VALUE_DESERIALIZER,
         getEnvVariableFromNode(streamIn.getSpec(), StaticConfig.VALUE_DESERIALIZER));
+    streamInConfig.put(StaticConfig.GROUP_ID, uuid);
 
     streamOutConfig.putIfAbsent(
         StaticConfig.BOOTSTRAP_SERVERS,

--- a/platform-api/src/main/java/io/datacater/core/deployment/StaticConfig.java
+++ b/platform-api/src/main/java/io/datacater/core/deployment/StaticConfig.java
@@ -37,6 +37,7 @@ public class StaticConfig {
   static final String LOCALHOST_BOOTSTRAP_SERVER = "localhost:9092";
   static final String KAFKA_TAG = "kafka";
   static final String TOPIC_TAG = "topic";
+  static final String GROUP_ID = "group.id";
   static final String BOOTSTRAP_SERVERS = "bootstrap.servers";
   static final String KEY_DESERIALIZER = "key.deserializer";
   static final String KEY_SERIALIZER = "key.serializer";

--- a/ui/src/helpers/getStreamConnectionOptions.js
+++ b/ui/src/helpers/getStreamConnectionOptions.js
@@ -14,7 +14,6 @@ export function getStreamConnectionOptions() {
     "enable.idempotence",
     "fetch.max.bytes",
     "fetch.min.bytes",
-    "group.id",
     "group.instance.id",
     "heartbeat.interval.ms",
     "isolation.level",


### PR DESCRIPTION
This PR adds a consumer `group.id` to our pipelines `stream-in` when creating a deployment.
The `group.id` is the uuid of the deployment.
If users add a `group-id` to the stream-config, it will be overwritten by us.