### PR TITLE
feat(ui): Allow debugging of failed transforms

### DIFF
--- a/ui/src/components/pipelines/PipelineDesigner.js
+++ b/ui/src/components/pipelines/PipelineDesigner.js
@@ -157,6 +157,7 @@ class PipelineDesigner extends Component {
             introducedFields={[]}
             moveStepFunc={this.props.moveStepFunc}
             moveToStepFunc={this.props.moveToStepFunc}
+            openDebugViewFunc={this.props.openDebugViewFunc}
             originalRecordsSize={this.props.originalRecordsSize}
             pipeline={this.props.pipeline}
             profile={this.props.profile}

--- a/ui/src/components/pipelines/pipeline_designer/grid/DebugView.js
+++ b/ui/src/components/pipelines/pipeline_designer/grid/DebugView.js
@@ -1,0 +1,167 @@
+import React, { Component } from "react";
+import { LifeBuoy } from "react-feather";
+import * as YAML from "json-to-pretty-yaml";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+
+class DebugView extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      tab: "error",
+    };
+    this.goToTab = this.goToTab.bind(this);
+  }
+
+  goToTab(event) {
+    event.preventDefault();
+
+    this.setState({
+      tab: event.target.dataset.tab,
+    });
+  }
+
+  render() {
+    const record = this.props.record;
+    const pipeline = this.props.pipeline;
+    const error = record.metadata["error"];
+
+    let debugContent = "Not available.";
+
+    if (this.state.tab === "error") {
+      debugContent = JSON.stringify(error, null, 2);
+    } else if (this.state.tab === "record") {
+      let originalRecord = JSON.parse(JSON.stringify(record));
+      delete originalRecord.metadata["error"];
+      delete originalRecord.id;
+      debugContent = JSON.stringify(originalRecord, null, 2);
+    } else if (this.state.tab === "transform") {
+      const match = /steps\[(\d+)\]\.fields\[(.+)\]/g.exec(
+        error["location"]["path"]
+      );
+      if (match != null && match.length == 3) {
+        const step = parseInt(match[1]);
+        const fieldName = match[2];
+        debugContent = YAML.stringify(
+          pipeline.spec.steps[step].fields[fieldName]
+        );
+      } else {
+        const match = /steps\[(\d+)\].*/g.exec(error["location"]["path"]);
+        if (match != null && match.length == 2) {
+          const step = parseInt(match[1]);
+          debugContent = YAML.stringify(pipeline.spec.steps[step]);
+        }
+      }
+    }
+
+    return (
+      <div className="modal d-block" tabIndex="-1">
+        <div className="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
+          <div className="modal-content">
+            <div className="modal-header">
+              <h5 className="modal-title align-items-center d-flex">
+                <LifeBuoy className="feather-icon me-2" /> Debug view for record
+                #{record.id}
+              </h5>
+              <button
+                type="button"
+                className="btn-close"
+                onClick={this.props.closeDebugViewFunc}
+                aria-label="Close"
+              ></button>
+            </div>
+            <div className="modal-body" style={{ height: "60vh" }}>
+              <ul className="nav nav-pills">
+                <li className="nav-item">
+                  {this.state.tab === "error" && (
+                    <a
+                      className="nav-link active"
+                      aria-current="error"
+                      href="#"
+                    >
+                      Error
+                    </a>
+                  )}
+                  {this.state.tab !== "error" && (
+                    <a
+                      onClick={this.goToTab}
+                      data-tab="error"
+                      className="nav-link"
+                      href="#"
+                    >
+                      Error
+                    </a>
+                  )}
+                </li>
+                <li className="nav-item">
+                  {this.state.tab === "record" && (
+                    <a
+                      className="nav-link active"
+                      aria-current="record"
+                      href="#"
+                    >
+                      Original record
+                    </a>
+                  )}
+                  {this.state.tab !== "record" && (
+                    <a
+                      onClick={this.goToTab}
+                      data-tab="record"
+                      className="nav-link"
+                      href="#"
+                    >
+                      Original record
+                    </a>
+                  )}
+                </li>
+                <li className="nav-item">
+                  {this.state.tab === "transform" && (
+                    <a
+                      className="nav-link active"
+                      aria-current="transform"
+                      href="#"
+                    >
+                      Failed transform
+                    </a>
+                  )}
+                  {this.state.tab !== "transform" && (
+                    <a
+                      onClick={this.goToTab}
+                      data-tab="transform"
+                      className="nav-link"
+                      href="#"
+                    >
+                      Failed transform
+                    </a>
+                  )}
+                </li>
+              </ul>
+              <SyntaxHighlighter
+                language="yaml"
+                showLineNumbers={true}
+                showInlineLineNumbers={true}
+                customStyle={{
+                  fontSize: "10px",
+                  marginBottom: "0px",
+                  background: "none",
+                }}
+              >
+                {debugContent}
+              </SyntaxHighlighter>
+            </div>
+            <div className="modal-footer">
+              <button
+                type="button"
+                className="btn btn-secondary"
+                onClick={this.props.closeDebugViewFunc}
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default DebugView;

--- a/ui/src/components/pipelines/pipeline_designer/grid/DebugView.js
+++ b/ui/src/components/pipelines/pipeline_designer/grid/DebugView.js
@@ -70,7 +70,7 @@ class DebugView extends Component {
               ></button>
             </div>
             <div className="modal-body" style={{ height: "60vh" }}>
-              <ul className="nav nav-pills">
+              <ul className="nav nav-pills mb-3">
                 <li className="nav-item">
                   {this.state.tab === "error" && (
                     <a
@@ -143,6 +143,7 @@ class DebugView extends Component {
                   fontSize: "10px",
                   marginBottom: "0px",
                   background: "none",
+                  border: "1px solid #dee2e6",
                 }}
               >
                 {debugContent}

--- a/ui/src/components/pipelines/pipeline_designer/grid/TableHeaderCell.js
+++ b/ui/src/components/pipelines/pipeline_designer/grid/TableHeaderCell.js
@@ -150,7 +150,7 @@ class TableHeaderCell extends Component {
     } else {
       return (
         <div className={className + " px-2"}>
-          {this.renderField(field, field.id)}
+          {this.renderField(field, field["__dc__id"])}
         </div>
       );
     }

--- a/ui/src/containers/pipelines/EditPipeline.js
+++ b/ui/src/containers/pipelines/EditPipeline.js
@@ -18,6 +18,7 @@ import {
 import { Modal } from "react-bootstrap";
 import BaseTable, { AutoResizer } from "react-base-table";
 import PipelineDesigner from "../../components/pipelines/PipelineDesigner";
+import DebugView from "../../components/pipelines/pipeline_designer/grid/DebugView";
 import Breadcrumb from "../../components/layout/Breadcrumb";
 import { getApiPathPrefix } from "../../helpers/getApiPathPrefix";
 import { deepCopy } from "../../helpers/deepCopy";
@@ -43,6 +44,7 @@ class EditPipeline extends Component {
       editColumn: undefined,
       contextBarActive: false,
       currentStep: undefined,
+      debugRecord: undefined,
       errorMessage: "",
       pipeline: {},
       pipelineUpdated: false,
@@ -70,6 +72,8 @@ class EditPipeline extends Component {
     this.updateStepName = this.updateStepName.bind(this);
     this.showStepNameForm = this.showStepNameForm.bind(this);
     this.hideStepNameForm = this.hideStepNameForm.bind(this);
+    this.openDebugView = this.openDebugView.bind(this);
+    this.closeDebugView = this.closeDebugView.bind(this);
   }
 
   componentDidMount() {
@@ -641,6 +645,17 @@ class EditPipeline extends Component {
       showStepNameForm: false,
     });
   }
+  openDebugView(record) {
+    this.setState({
+      debugRecord: record,
+    });
+  }
+
+  closeDebugView() {
+    this.setState({
+      debugRecord: undefined,
+    });
+  }
 
   render() {
     const pipeline = this.state.pipeline;
@@ -743,12 +758,8 @@ class EditPipeline extends Component {
     const sampleRecords =
       this.state.currentStep === undefined ||
       this.props.pipelines.inspectionResult === undefined
-        ? deepCopy(this.props.streams.inspectionResult).map(
-            (record) => record.value
-          )
-        : deepCopy(this.props.pipelines.inspectionResult).map(
-            (record) => record.value
-          );
+        ? deepCopy(this.props.streams.inspectionResult)
+        : deepCopy(this.props.pipelines.inspectionResult);
 
     if (sampleRecords.length === 0) {
       return (
@@ -781,6 +792,13 @@ class EditPipeline extends Component {
     return (
       <>
         <div className="container">{header}</div>
+        {this.state.debugRecord !== undefined && (
+          <DebugView
+            closeDebugViewFunc={this.closeDebugView}
+            pipeline={this.state.pipeline}
+            record={this.state.debugRecord}
+          />
+        )}
         {sampleRecords.length > 0 && (
           <PipelineDesigner
             addStepFunc={this.addStep}
@@ -796,6 +814,7 @@ class EditPipeline extends Component {
             hideStepNameFormFunc={this.hideStepNameForm}
             moveToStepFunc={this.moveToStep}
             moveStepFunc={this.moveStep}
+            openDebugViewFunc={this.openDebugView}
             pipeline={pipeline}
             previewState={{}}
             profile={profile}

--- a/ui/src/helpers/profileRecords.js
+++ b/ui/src/helpers/profileRecords.js
@@ -49,8 +49,9 @@ export function profileRecords(records) {
   const profile = {};
 
   records.forEach(function (record) {
-    Object.keys(record).forEach(function (fieldName) {
-      const value = record[fieldName];
+    const recordValue = record["value"];
+    Object.keys(recordValue).forEach(function (fieldName) {
+      const value = recordValue[fieldName];
       if (profile[fieldName] === undefined) {
         profile[fieldName] = Object.assign({}, profileTemplate, {
           dataType: getDataType(value),

--- a/ui/src/scss/grid.scss
+++ b/ui/src/scss/grid.scss
@@ -181,7 +181,7 @@ $row-hovered-background-color: #f5f5f5;
     }
 
     .sample-cell.error-in-current-step {
-      background-color: #cc3a38;
+      background-color: #e76666;
       color: #fff;
     }
 

--- a/ui/src/scss/grid.scss
+++ b/ui/src/scss/grid.scss
@@ -179,6 +179,15 @@ $row-hovered-background-color: #f5f5f5;
     .sample-cell.changed-in-previous-step {
       background-color: #dff1e1;
     }
+
+    .sample-cell.error-in-current-step {
+      background-color: #cc3a38;
+      color: #fff;
+    }
+
+    .sample-cell.error-in-previous-step {
+      background-color: #f5b7b1;
+    }
   }
 
   &-filters &__table-main &__row-cell,


### PR DESCRIPTION
This PR extends our UI-based pipeline designer with debugging capabilities.

When applying a transform to a record fails, our Python runner extends the `metadata` field of the record with an `error` object. We now read this field and visually highlight the record in the UI with a red background color:

![Screenshot 2022-11-21 at 15 16 33](https://user-images.githubusercontent.com/128683/203079657-ee0d75dd-4f46-4167-a19d-b6b03ae8dbea.png)

Users can click the affected record to open a "debug view", which provides access to the description of the error including a stacktrace, to the original record, and the configuration of the transform that failed:

![Screenshot 2022-11-21 at 15 21 51](https://user-images.githubusercontent.com/128683/203079729-9ab4186f-a8c7-4c36-8922-11e18fcf4c0a.png)
![Screenshot 2022-11-21 at 15 17 40](https://user-images.githubusercontent.com/128683/203079758-de2023e7-20d8-4b22-97ac-403209a948d3.png)
![Screenshot 2022-11-21 at 15 21 56](https://user-images.githubusercontent.com/128683/203079775-b7ae1d51-e490-4fc1-af64-78c77da19d2d.png)

Please consider this PR as a discussion. I am not yet 100% happy with the implementation.

I would appreciate it if you could check out the PR branch locally and play with the debug view. Please let me know what you think about it and whether this debug view helps you debugging errors in the preview of the pipeline designer.