### PR TITLE
feat(pipeline): Handle ConnectExceptions

### DIFF
--- a/pipeline/src/main/java/io/datacater/PipelineConfig.java
+++ b/pipeline/src/main/java/io/datacater/PipelineConfig.java
@@ -36,4 +36,12 @@ public class PipelineConfig {
     static final String OFFSET = "offset";
     static final String PARTITION = "partition";
     static final String PIPELINE_ERROR_MSG = "Pipeline could not process message.\n Key: %s\n Value: %s";
+    /*
+     * Number of retries in case of a failed connection attempt
+     */
+    static final Integer CONNECTION_RETRIES = 10;
+    /**
+     * Number of milliseconds to wait between retrying to connect
+     */
+    static final Integer CONNECTION_RETRY_WAIT = 1000;
 }


### PR DESCRIPTION
DataCater deployments use a sidecar, `python-runner`, for evaluating pipeline specifications.

If the sidecar is not (yet) available, accessing it will throw a `java.net.ConnectException`, nacking the processed record.

This can be easily reproduced when using a `stream-in` with the consumer configuration `auto.offset.reset = earliest`. The sidecar takes longer to spin up than the Quarkus application, thus always leading to nacked messages.

This commit introduces two configuration options:
* `PipelineConfig.CONNECTION_RETRIES`: Number of retries to perform when accessing the sidecar throws a `ConnectException` (default: `10`)
* `PipelineConfig.CONNECTION_RETRY_WAIT`: Number of milliseconds to wait between different connection attempts, leaving time for the sidecar to become available (default: `1000`)

The Quarkus application now tries to perform up to `PipelineConfig.CONNECTION_RETRIES` connection attempts when accessing the sidecar before it fails and nacks the messages.