### PR TITLE
feat(ui/streams): Show a warning if `group.id` is set

### DIFF
--- a/ui/src/containers/streams/EditStream.js
+++ b/ui/src/containers/streams/EditStream.js
@@ -520,6 +520,13 @@ class EditStream extends Component {
                 />
               </div>
             ))}
+            {this.state.stream.spec.kafka["group.id"] !== undefined && (
+              <div className="col-12 mt-4 alert alert-warning">
+                Setting the consumer property <i>group.id</i> does not have any
+                impact because DataCater overwrites it with the Deployment's
+                UUID.
+              </div>
+            )}
             <div className="col-12 mt-3">
               <h6 className="d-inline me-2">Add config</h6>
               <span className="text-muted fs-7">

--- a/ui/src/containers/streams/NewStream.js
+++ b/ui/src/containers/streams/NewStream.js
@@ -500,6 +500,13 @@ class NewStream extends Component {
                 />
               </div>
             ))}
+            {this.state.stream.spec.kafka["group.id"] !== undefined && (
+              <div className="col-12 mt-4 alert alert-warning">
+                Setting the consumer property <i>group.id</i> does not have any
+                impact because DataCater overwrites it with the Deployment's
+                UUID.
+              </div>
+            )}
             <div className="col-12 mt-3">
               <h6 className="d-inline me-2">Add config</h6>
               <span className="text-muted fs-7">


### PR DESCRIPTION
Show a warning if a stream defined the consumer property `group.id` because DataCater automatically overwrites it when starting a Deployment.

Fixes #64