### PR TITLE
feat(api): Update version to v1

### DIFF
--- a/platform-api/src/main/resources/application.yml
+++ b/platform-api/src/main/resources/application.yml
@@ -66,7 +66,7 @@ datacater:
       version: alpha-20221101
   authorization: true
   api:
-    version: alpha
+    version: v1
   kafka:
     api:
       timeout:

--- a/ui/src/helpers/getApiPathPrefix.js
+++ b/ui/src/helpers/getApiPathPrefix.js
@@ -1,6 +1,6 @@
 export function getApiPathPrefix(includeHostname = false) {
   const hostname = window.location.protocol + "//" + window.location.host;
-  const pathPrefix = "/api/alpha";
+  const pathPrefix = "/api/v1";
 
   if (includeHostname) {
     return hostname + pathPrefix;


### PR DESCRIPTION
This updates our API prefix from `/api/alpha` to `/api/v1`.

Once we have built the first release after merging this PR, we need to update the paths in [our documentation](https://docs.datacater.io/introduction/welcome) and [Kubernetes health probes](https://github.com/DataCater/datacater/blob/main/k8s-manifests/minikube-with-postgres-ns-default.yaml).