### PR TITLE
feat(deployments): Allow deletion of deployments if no K8 object exists

### DIFF
--- a/platform-api/src/main/java/io/datacater/core/deployment/DeploymentEndpoint.java
+++ b/platform-api/src/main/java/io/datacater/core/deployment/DeploymentEndpoint.java
@@ -3,6 +3,7 @@ package io.datacater.core.deployment;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.datacater.core.exceptions.*;
+import io.datacater.core.pipeline.PipelineEndpoint;
 import io.datacater.core.pipeline.PipelineEntity;
 import io.datacater.core.stream.StreamEntity;
 import io.datacater.core.utilities.StringUtilities;
@@ -32,6 +33,7 @@ import javax.ws.rs.sse.Sse;
 import javax.ws.rs.sse.SseEventSink;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
 import org.hibernate.reactive.mutiny.Mutiny;
+import org.jboss.logging.Logger;
 
 @Path("/deployments")
 @RolesAllowed("dev")
@@ -39,6 +41,9 @@ import org.hibernate.reactive.mutiny.Mutiny;
 @SecurityRequirement(name = "apiToken")
 @RequestScoped
 public class DeploymentEndpoint {
+
+  static final Logger LOGGER = Logger.getLogger(DeploymentEndpoint.class);
+
   @Inject Mutiny.SessionFactory sf;
 
   @Inject KubernetesClient client;
@@ -331,8 +336,15 @@ public class DeploymentEndpoint {
   }
 
   private void deleteK8Deployment(UUID deploymentId) {
-    K8Deployment k8Deployment = new K8Deployment(client);
-    k8Deployment.delete(deploymentId);
+    try {
+      K8Deployment k8Deployment = new K8Deployment(client);
+      k8Deployment.delete(deploymentId);
+    } catch (DeploymentNotFoundException e) {
+      LOGGER.error(
+              String.format("Could not find Kubernetes deployment with id %s", deploymentId.toString()),
+              e
+      );
+    }
   }
 
   private DeploymentEntity createDeployment(

--- a/platform-api/src/main/java/io/datacater/core/deployment/DeploymentEndpoint.java
+++ b/platform-api/src/main/java/io/datacater/core/deployment/DeploymentEndpoint.java
@@ -3,7 +3,6 @@ package io.datacater.core.deployment;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.datacater.core.exceptions.*;
-import io.datacater.core.pipeline.PipelineEndpoint;
 import io.datacater.core.pipeline.PipelineEntity;
 import io.datacater.core.stream.StreamEntity;
 import io.datacater.core.utilities.StringUtilities;
@@ -341,9 +340,8 @@ public class DeploymentEndpoint {
       k8Deployment.delete(deploymentId);
     } catch (DeploymentNotFoundException e) {
       LOGGER.error(
-              String.format("Could not find Kubernetes deployment with id %s", deploymentId.toString()),
-              e
-      );
+          String.format("Could not find Kubernetes deployment with id %s", deploymentId.toString()),
+          e);
     }
   }
 


### PR DESCRIPTION
Allow to delete a DataCater deployment even if the underlying Kubernetes Deployment does not exist in the Kubernetes cluster.

This can be the case if a Kubernetes administrator has deleted the resource directly in Kubernetes, bypassing the DataCater API.

Fixes #74