### PR TITLE
feat(pipeline): Improve error logging

### DIFF
--- a/pipeline/src/main/java/io/datacater/Pipeline.java
+++ b/pipeline/src/main/java/io/datacater/Pipeline.java
@@ -7,7 +7,6 @@ import io.vertx.core.json.JsonObject;
 import io.smallrye.reactive.messaging.kafka.Record;
 
 import java.time.Duration;
-import java.util.UUID;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import java.net.ConnectException;
@@ -94,7 +93,7 @@ public class Pipeline {
     messages.stream().forEach(x -> {
       if(x instanceof JsonObject json){
         if(json.getJsonObject(PipelineConfig.METADATA).containsKey(PipelineConfig.ERROR)){
-          logMessage(json.encodePrettily());
+          logProcessingError(json);
         }
         sendRecord(Record.of(getKey(json), json.getJsonObject(PipelineConfig.VALUE)));
       }
@@ -105,8 +104,15 @@ public class Pipeline {
     producer.send(record);
   }
 
-  private void logMessage(String message){
-    String errorMsg = String.format(PipelineConfig.PIPELINE_ERROR_MSG, message);
+  private void logProcessingError(JsonObject record){
+    String errorMsg = String.format(
+            PipelineConfig.PIPELINE_ERROR_MSG,
+            record.getValue("key").toString(),
+            record.getValue("value").toString(),
+            record.getValue(PipelineConfig.METADATA),
+            record.getJsonObject(PipelineConfig.METADATA)
+                    .getJsonObject(PipelineConfig.ERROR)
+                    .encodePrettily());
     LOGGER.error(errorMsg);
   }
 

--- a/pipeline/src/main/java/io/datacater/Pipeline.java
+++ b/pipeline/src/main/java/io/datacater/Pipeline.java
@@ -107,8 +107,8 @@ public class Pipeline {
   private void logProcessingError(JsonObject record){
     String errorMsg = String.format(
             PipelineConfig.PIPELINE_ERROR_MSG,
-            record.getValue("key").toString(),
-            record.getValue("value").toString(),
+            record.getValue(PipelineConfig.KEY).toString(),
+            record.getValue(PipelineConfig.VALUE).toString(),
             record.getValue(PipelineConfig.METADATA),
             record.getJsonObject(PipelineConfig.METADATA)
                     .getJsonObject(PipelineConfig.ERROR)

--- a/pipeline/src/main/java/io/datacater/PipelineConfig.java
+++ b/pipeline/src/main/java/io/datacater/PipelineConfig.java
@@ -35,7 +35,8 @@ public class PipelineConfig {
     static final String ERROR = "error";
     static final String OFFSET = "offset";
     static final String PARTITION = "partition";
-    static final String PIPELINE_ERROR_MSG = "Pipeline could not process message.\n Key: %s\n Value: %s";
+    static final String PIPELINE_ERROR_MSG =
+            "Pipeline could not process record.\n Key: %s\n Value: %s\n Metadata: %s\n Error: %s";
     /*
      * Number of retries in case of a failed connection attempt
      */


### PR DESCRIPTION
When the processing of a record fails, log the following information:
* key of the record
* value of the record
* metadata of the record (e.g., offset)
* detailed information on the error (e.g., exception name, exception message, stacktrace, etc.)

Fixes #61