### PR TITLE
Feature/pipeline performance

### DIFF
--- a/pipeline/src/main/java/io/datacater/Pipeline.java
+++ b/pipeline/src/main/java/io/datacater/Pipeline.java
@@ -152,10 +152,10 @@ public class Pipeline {
   }
 
   private void handleMessages(ConsumerRecords<byte[], byte[]> messages) throws IOException {
-    if (PipelineConfig.DATACATER_PYTHONRUNNER_PROTOCOL.equals("http")) {
-      handleMessagesViaHttp(messages);
-    } else {
+    if (PipelineConfig.DATACATER_PYTHONRUNNER_PROTOCOL.contains("file")) {
       handleMessagesViaFile(messages);
+    } else {
+      handleMessagesViaHttp(messages);
     }
   }
 

--- a/pipeline/src/main/java/io/datacater/Pipeline.java
+++ b/pipeline/src/main/java/io/datacater/Pipeline.java
@@ -101,7 +101,7 @@ public class Pipeline {
 
   private void handleMessagesViaFile(ConsumerRecords<byte[], byte[]> messages) throws IOException {
     HttpRequest<Buffer> request = client
-            .post(getPort(), getHost(), PipelineConfig.ENDPOINT)
+            .post(getPort(), getHost(), PipelineConfig.FILE_ENDPOINT)
             .putHeader(PipelineConfig.HEADER, PipelineConfig.HEADER_TYPE);
 
     // Write deserialized messages to temporary file
@@ -136,7 +136,7 @@ public class Pipeline {
 
   private void handleMessagesViaHttp(ConsumerRecords<byte[], byte[]> messages) {
     HttpRequest<Buffer> request = client
-            .post(getPort(), getHost(), PipelineConfig.ENDPOINT)
+            .post(getPort(), getHost(), PipelineConfig.HTTP_ENDPOINT)
             .putHeader(PipelineConfig.HEADER, PipelineConfig.HEADER_TYPE);
 
     HttpResponse<Buffer> response = request
@@ -152,10 +152,10 @@ public class Pipeline {
   }
 
   private void handleMessages(ConsumerRecords<byte[], byte[]> messages) throws IOException {
-    if (PipelineConfig.DATACATER_PYTHONRUNNER_PROTOCOL.contains("file")) {
-      handleMessagesViaFile(messages);
-    } else {
+    if (PipelineConfig.DATACATER_PYTHONRUNNER_PROTOCOL.contains("http")) {
       handleMessagesViaHttp(messages);
+    } else {
+      handleMessagesViaFile(messages);
     }
   }
 

--- a/pipeline/src/main/java/io/datacater/Pipeline.java
+++ b/pipeline/src/main/java/io/datacater/Pipeline.java
@@ -69,7 +69,7 @@ public class Pipeline {
     try {
       // This is deliberately blocking
       handleMessages(messages);
-    } catch (CompletionException | ConnectException e) {
+    } catch (CompletionException | IOException e) {
       LOGGER.warn("Connection to Python-Runner sidecar failed: %s. Attempt: 0".format(e.getMessage()), e);
 
       int retries = 0;

--- a/pipeline/src/main/java/io/datacater/PipelineConfig.java
+++ b/pipeline/src/main/java/io/datacater/PipelineConfig.java
@@ -24,6 +24,11 @@ public class PipelineConfig {
                     .getOptionalValue("datacater.python-runner.timeout", Integer.class)
                     .orElse(60);
 
+    static final String DATACATER_PYTHONRUNNER_PROTOCOL =
+            ConfigProvider.getConfig()
+                    .getOptionalValue("datacater.python-runner.protocol", String.class)
+                    .orElse("file");
+
     static final String STREAM_IN = "stream-in";
     static final String STREAM_OUT = "stream-out";
     static final String ENDPOINT = "/batch-file";

--- a/pipeline/src/main/java/io/datacater/PipelineConfig.java
+++ b/pipeline/src/main/java/io/datacater/PipelineConfig.java
@@ -27,11 +27,12 @@ public class PipelineConfig {
     static final String DATACATER_PYTHONRUNNER_PROTOCOL =
             ConfigProvider.getConfig()
                     .getOptionalValue("datacater.python-runner.protocol", String.class)
-                    .orElse("http");
+                    .orElse("file");
 
     static final String STREAM_IN = "stream-in";
     static final String STREAM_OUT = "stream-out";
-    static final String ENDPOINT = "/batch-file";
+    static final String FILE_ENDPOINT = "/batch-file";
+    static final String HTTP_ENDPOINT = "/batch";
     static final String HEADER = "Content-Type";
     static final String HEADER_TYPE = "application/json";
     static final String KEY = "key";

--- a/pipeline/src/main/java/io/datacater/PipelineConfig.java
+++ b/pipeline/src/main/java/io/datacater/PipelineConfig.java
@@ -27,7 +27,7 @@ public class PipelineConfig {
     static final String DATACATER_PYTHONRUNNER_PROTOCOL =
             ConfigProvider.getConfig()
                     .getOptionalValue("datacater.python-runner.protocol", String.class)
-                    .orElse("file");
+                    .orElse("http");
 
     static final String STREAM_IN = "stream-in";
     static final String STREAM_OUT = "stream-out";

--- a/pipeline/src/main/java/io/datacater/PipelineConfig.java
+++ b/pipeline/src/main/java/io/datacater/PipelineConfig.java
@@ -26,7 +26,7 @@ public class PipelineConfig {
 
     static final String STREAM_IN = "stream-in";
     static final String STREAM_OUT = "stream-out";
-    static final String ENDPOINT = "/batch";
+    static final String ENDPOINT = "/batch-file";
     static final String HEADER = "Content-Type";
     static final String HEADER_TYPE = "application/json";
     static final String KEY = "key";
@@ -45,4 +45,5 @@ public class PipelineConfig {
      * Number of milliseconds to wait between retrying to connect
      */
     static final Integer CONNECTION_RETRY_WAIT = 1000;
+    static final String DATA_SHARE_MOUNT_PATH = "/usr/app/data-mounts";
 }

--- a/pipeline/src/main/resources/application.yml
+++ b/pipeline/src/main/resources/application.yml
@@ -21,11 +21,16 @@ mp       :
         merge: true
         connector: smallrye-kafka
         kafka-configuration: stream-out-configuration
+        max-inflight-messages: 0
         topic: stream-out
+        waitForWriteCompletion: false
     incoming:
       stream-in:
+        auto.commit.interval.ms: 10000
         batch: true
         connector: smallrye-kafka
+        commit-strategy: throttled
+        fetch.min.bytes: 102400
         max:
           poll:
             records: ${datacater.message.batch.size}
@@ -38,7 +43,7 @@ datacater:
     version: alpha-20221129
   message:
     batch:
-      size: 100
+      size: 2500
   stream-in:
     config: '{"key.deserializer": "io.datacater.core.serde.JsonDeserializer", "value.deserializer": "io.datacater.core.serde.JsonDeserializer"}'
   stream-out:

--- a/pipeline/src/main/resources/application.yml
+++ b/pipeline/src/main/resources/application.yml
@@ -41,6 +41,7 @@ datacater:
     port: 50000
     host: localhost
     version: alpha-20221129
+    protocol: file
   message:
     batch:
       size: 2500
@@ -61,10 +62,12 @@ datacater:
       port: 50000
       host: localhost
       version: alpha-20221129
+      protocol: http
 
 '%test'  :
   datacater:
     python-runner:
+      protocol: http
       version: alpha-20221129
   quarkus:
     log:

--- a/pipeline/src/main/resources/application.yml
+++ b/pipeline/src/main/resources/application.yml
@@ -21,16 +21,11 @@ mp       :
         merge: true
         connector: smallrye-kafka
         kafka-configuration: stream-out-configuration
-        max-inflight-messages: 0
         topic: stream-out
-        waitForWriteCompletion: false
     incoming:
       stream-in:
-        auto.commit.interval.ms: 10000
         batch: true
         connector: smallrye-kafka
-        commit-strategy: throttled
-        fetch.min.bytes: 102400
         max:
           poll:
             records: ${datacater.message.batch.size}

--- a/platform-api/src/main/java/io/datacater/core/deployment/StaticConfig.java
+++ b/platform-api/src/main/java/io/datacater/core/deployment/StaticConfig.java
@@ -19,13 +19,15 @@ public class StaticConfig {
   static final String UUID_TEXT = "datacater.io/uuid";
   static final String DEPLOYMENT_NAME_TEXT = "datacater.io/name";
   static final String DEPLOYMENT_SERVICE_TEXT = "datacater.io/service";
-  static final String MOUNT_PATH = "/usr/app/mounts";
+  static final String CONFIGMAP_MOUNT_PATH = "/usr/app/mounts";
+  static final String DATA_SHARE_MOUNT_PATH = "/usr/app/data-mounts";
   static final Map<String, Quantity> RESOURCE_REQUESTS =
       Map.of("cpu", new Quantity("0.1"), "memory", new Quantity("1.5Gi"));
   static final Map<String, Quantity> RESOURCE_LIMITS = Map.of("memory", new Quantity("4Gi"));
   static final String DEPLOYMENT_NAME_PREFIX = "datacater-deployment-";
   static final String CONFIGMAP_NAME_PREFIX = "datacater-configmap-";
-  static final String VOLUME_NAME_PREFIX = "datacater-volume-";
+  static final String CONFIGMAP_VOLUME_NAME_PREFIX = "datacater-volume-";
+  static final String DATA_SHARE_VOLUME_NAME_PREFIX = "datacater-volume-data-";
   static final String SERVICE_NAME_PREFIX = "datacater-service-";
   static final String NONE = "None";
   static final String TCP_TAG = "TCP";

--- a/python-runner/runner.py
+++ b/python-runner/runner.py
@@ -77,6 +77,7 @@ if path.isfile(CONFIG_MAP_FILE):
     pipeline["spec"] = json.loads(config_map.read())
     config_map.close()
 
+
 def apply_pipeline(record: dict, pipeline: dict, preview_step=None):
     location = {}
     try:
@@ -226,6 +227,7 @@ def apply_pipeline(record: dict, pipeline: dict, preview_step=None):
 
         return record
 
+
 @app.post("/batch")
 async def apply_to_multiple_records(records: List[dict], response: Response):
     processed_records = []
@@ -234,6 +236,7 @@ async def apply_to_multiple_records(records: List[dict], response: Response):
         if processed_record is not None:
             processed_records.append(processed_record)
     return processed_records
+
 
 @app.post("/batch-file")
 async def apply_to_multiple_records_file(request: dict, response: Response):
@@ -245,9 +248,9 @@ async def apply_to_multiple_records_file(request: dict, response: Response):
             processed_record = apply_pipeline(record, pipeline)
             if processed_record is not None:
                 processed_records.append(processed_record)
-        with open(temp_file + ".out", 'w') as outfile:
+        with open(temp_file + ".out", "w") as outfile:
             json.dump(processed_records, outfile)
-    return { "fileOut": temp_file + ".out" }
+    return {"fileOut": temp_file + ".out"}
 
 
 @app.post("/preview")

--- a/python-runner/test_runner.py
+++ b/python-runner/test_runner.py
@@ -1,10 +1,44 @@
 # Run tests: $ python3 -m pytest
 
 from fastapi.testclient import TestClient
+import json
+import os
 
 from runner import app
 
 client = TestClient(app)
+
+
+def test_batch_file_apply_transform():
+    # Upload pipeline
+    client.post(
+        "/pipeline",
+        json={
+            "spec": {
+                "steps": [
+                    {
+                        "kind": "Field",
+                        "fields": {"company": {"transform": {"key": "trim"}}},
+                    }
+                ]
+            }
+        },
+    )
+    # Apply pipeline to records
+    raw_records = [{"key": {}, "value": {"company": " DataCater GmbH     "}, "metadata": {}}]
+    with open("records.json", 'w') as outfile:
+        json.dump(raw_records, outfile)
+    response = client.post(
+        "/batch-file",
+        json = {"fileIn": "records.json"}
+    )
+    assert response.status_code == 200
+    with open(response.json()["fileOut"]) as infile:
+        assert json.load(infile) == [
+            {"key": {}, "value": {"company": "DataCater GmbH"}, "metadata": {}}
+        ]
+    os.remove("records.json")
+    os.remove("records.json.out")
 
 
 def test_batch_apply_transform():

--- a/python-runner/test_runner.py
+++ b/python-runner/test_runner.py
@@ -25,13 +25,12 @@ def test_batch_file_apply_transform():
         },
     )
     # Apply pipeline to records
-    raw_records = [{"key": {}, "value": {"company": " DataCater GmbH     "}, "metadata": {}}]
-    with open("records.json", 'w') as outfile:
+    raw_records = [
+        {"key": {}, "value": {"company": " DataCater GmbH     "}, "metadata": {}}
+    ]
+    with open("records.json", "w") as outfile:
         json.dump(raw_records, outfile)
-    response = client.post(
-        "/batch-file",
-        json = {"fileIn": "records.json"}
-    )
+    response = client.post("/batch-file", json={"fileIn": "records.json"})
     assert response.status_code == 200
     with open(response.json()["fileOut"]) as infile:
         assert json.load(infile) == [


### PR DESCRIPTION
This PR improves the performance of our pipelines by enabling the communication between the Quarkus pipeline and the Python runner via [shared volumes](https://kubernetes.io/docs/tasks/access-application-cluster/communicate-containers-same-pod-shared-volume/) instead of HTTP.

This gives us a performance boost of around 500% in terms of throughput.

For development and testing purposes, we can still switch back to HTTP-based communication by setting the configuration `datacater.python-runner.procotol` to `http` (default: `file`).

Communication between Quarkus and Python happens as follows:
* When the Quarkus pipelines receives a new batch of records, it writes the records in the JSON format into a temporary file on a shared volume.
* Then it calls the endpoint `/batch-file` of the Python runner and provides the name of the temporary file on the shared volume in the request body.
* In the next step, the Python runner reads the unprocessed records from the temporary file, applies the pipeline spec to them, and writes the processed records into another temporary file on the shared volume. It returns the name of the new temporary file in the response body to the Quarkus pipeline.
* The Quarkus pipeline reads the processed records from the new temporary file and publishes them to the stream out.
* The Quarkus pipeline cleans up all temporary files.