### PR TITLE
feat(ui): Sort resources by their update time

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^0.27.2",
         "bootstrap": "^5.2.1",
+        "javascript-time-ago": "^2.5.9",
         "json-to-pretty-yaml": "^1.2.2",
         "npm": "^8.19.2",
         "parse-prometheus-text-format": "^1.1.1",
@@ -10457,6 +10458,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/javascript-time-ago": {
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/javascript-time-ago/-/javascript-time-ago-2.5.9.tgz",
+      "integrity": "sha512-pQ8mNco/9g9TqWXWWjP0EWl6i/lAQScOyEeXy5AB+f7MfLSdgyV9BJhiOD1zrIac/lrxPYOWNbyl/IW8CW5n0A==",
+      "dependencies": {
+        "relative-time-format": "^1.1.6"
+      }
+    },
     "node_modules/jest": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
@@ -17538,6 +17547,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/relative-time-format": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/relative-time-format/-/relative-time-format-1.1.6.tgz",
+      "integrity": "sha512-aCv3juQw4hT1/P/OrVltKWLlp15eW1GRcwP1XdxHrPdZE9MtgqFpegjnTjLhi2m2WI9MT/hQQtE+tjEWG1hgkQ=="
     },
     "node_modules/remedial": {
       "version": "1.0.8",
@@ -28421,6 +28435,14 @@
         "minimatch": "^3.0.4"
       }
     },
+    "javascript-time-ago": {
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/javascript-time-ago/-/javascript-time-ago-2.5.9.tgz",
+      "integrity": "sha512-pQ8mNco/9g9TqWXWWjP0EWl6i/lAQScOyEeXy5AB+f7MfLSdgyV9BJhiOD1zrIac/lrxPYOWNbyl/IW8CW5n0A==",
+      "requires": {
+        "relative-time-format": "^1.1.6"
+      }
+    },
     "jest": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
@@ -33318,6 +33340,11 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog=="
+    },
+    "relative-time-format": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/relative-time-format/-/relative-time-format-1.1.6.tgz",
+      "integrity": "sha512-aCv3juQw4hT1/P/OrVltKWLlp15eW1GRcwP1XdxHrPdZE9MtgqFpegjnTjLhi2m2WI9MT/hQQtE+tjEWG1hgkQ=="
     },
     "remedial": {
       "version": "1.0.8",

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "axios": "^0.27.2",
     "bootstrap": "^5.2.1",
+    "javascript-time-ago": "^2.5.9",
     "json-to-pretty-yaml": "^1.2.2",
     "npm": "^8.19.2",
     "parse-prometheus-text-format": "^1.1.1",

--- a/ui/src/components/pipelines/pipeline_designer/context_bar/CodeEditor.js
+++ b/ui/src/components/pipelines/pipeline_designer/context_bar/CodeEditor.js
@@ -72,10 +72,10 @@ class CodeEditor extends Component {
   }
 
   handleChange(value, event) {
-    const unsavedChanges = unsavedChanges || (value !== this.state.code);
+    const unsavedChanges = unsavedChanges || value !== this.state.code;
     this.setState({
       code: value,
-      unsavedChanges: unsavedChanges
+      unsavedChanges: unsavedChanges,
     });
   }
 
@@ -92,7 +92,7 @@ class CodeEditor extends Component {
     );
 
     this.setState({
-      unsavedChanges: false
+      unsavedChanges: false,
     });
   }
 
@@ -108,10 +108,7 @@ class CodeEditor extends Component {
             Python®
           </div>
           <div className="col-auto">
-            <button
-              className={buttonClassNames}
-              onClick={this.handleApply}
-            >
+            <button className={buttonClassNames} onClick={this.handleApply}>
               <Play className="feather-icon" />
               Save &amp; Run
             </button>

--- a/ui/src/containers/deployments/ListDeployments.js
+++ b/ui/src/containers/deployments/ListDeployments.js
@@ -90,8 +90,8 @@ class ListDeployments extends Component {
                     </div>
                     {deployment.updatedAt !== undefined &&
                       !isNaN(Date.parse(deployment.updatedAt)) && (
-                        <div className="d-flex w-100 justify-content-between mb-1">
-                          <small className="d-flex align-items-center text-muted">
+                        <div className="d-flex w-100 justify-content-end">
+                          <small className="text-muted">
                             Last modified:{" "}
                             {timeAgo.format(new Date(deployment.updatedAt))}
                           </small>

--- a/ui/src/containers/deployments/ListDeployments.js
+++ b/ui/src/containers/deployments/ListDeployments.js
@@ -2,6 +2,8 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import Breadcrumb from "../../components/layout/Breadcrumb";
 import Header from "../../components/layout/Header";
+import TimeAgo from "javascript-time-ago";
+import en from "javascript-time-ago/locale/en";
 import { fetchDeployments } from "../../actions/deployments";
 
 class ListDeployments extends Component {
@@ -10,8 +12,6 @@ class ListDeployments extends Component {
   }
 
   render() {
-    const deployments = this.props.deployments.deployments;
-
     if (![undefined, ""].includes(this.props.deployments.errorMessage)) {
       return (
         <div className="container">
@@ -24,6 +24,13 @@ class ListDeployments extends Component {
         </div>
       );
     }
+
+    const deployments = this.props.deployments.deployments.sort(
+      (a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt)
+    );
+
+    TimeAgo.addDefaultLocale(en);
+    const timeAgo = new TimeAgo("en-US");
 
     return (
       <div className="container">
@@ -81,6 +88,15 @@ class ListDeployments extends Component {
                         {deployment.uuid}
                       </small>
                     </div>
+                    {deployment.updatedAt !== undefined &&
+                      !isNaN(Date.parse(deployment.updatedAt)) && (
+                        <div className="d-flex w-100 justify-content-between mb-1">
+                          <small className="d-flex align-items-center text-muted">
+                            Last modified:{" "}
+                            {timeAgo.format(new Date(deployment.updatedAt))}
+                          </small>
+                        </div>
+                      )}
                   </a>
                 ))}
               </div>

--- a/ui/src/containers/pipelines/ListPipelines.js
+++ b/ui/src/containers/pipelines/ListPipelines.js
@@ -2,6 +2,8 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import Breadcrumb from "../../components/layout/Breadcrumb";
 import Header from "../../components/layout/Header";
+import TimeAgo from "javascript-time-ago";
+import en from "javascript-time-ago/locale/en";
 import { fetchPipelines } from "../../actions/pipelines";
 
 class ListPipelines extends Component {
@@ -10,8 +12,6 @@ class ListPipelines extends Component {
   }
 
   render() {
-    const pipelines = this.props.pipelines.pipelines;
-
     if (![undefined, ""].includes(this.props.pipelines.errorMessage)) {
       return (
         <div className="container">
@@ -24,6 +24,13 @@ class ListPipelines extends Component {
         </div>
       );
     }
+
+    const pipelines = this.props.pipelines.pipelines.sort(
+      (a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt)
+    );
+
+    TimeAgo.addDefaultLocale(en);
+    const timeAgo = new TimeAgo("en-US");
 
     return (
       <div className="container">
@@ -81,6 +88,15 @@ class ListPipelines extends Component {
                         {pipeline.uuid}
                       </small>
                     </div>
+                    {pipeline.updatedAt !== undefined &&
+                      !isNaN(Date.parse(pipeline.updatedAt)) && (
+                        <div className="d-flex w-100 justify-content-between mb-1">
+                          <small className="d-flex align-items-center text-muted">
+                            Last modified:{" "}
+                            {timeAgo.format(new Date(pipeline.updatedAt))}
+                          </small>
+                        </div>
+                      )}
                   </a>
                 ))}
               </div>

--- a/ui/src/containers/pipelines/ListPipelines.js
+++ b/ui/src/containers/pipelines/ListPipelines.js
@@ -90,8 +90,8 @@ class ListPipelines extends Component {
                     </div>
                     {pipeline.updatedAt !== undefined &&
                       !isNaN(Date.parse(pipeline.updatedAt)) && (
-                        <div className="d-flex w-100 justify-content-between mb-1">
-                          <small className="d-flex align-items-center text-muted">
+                        <div className="d-flex w-100 justify-content-end">
+                          <small className="text-muted">
                             Last modified:{" "}
                             {timeAgo.format(new Date(pipeline.updatedAt))}
                           </small>

--- a/ui/src/containers/streams/ListStreams.js
+++ b/ui/src/containers/streams/ListStreams.js
@@ -2,6 +2,8 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import Breadcrumb from "../../components/layout/Breadcrumb";
 import Header from "../../components/layout/Header";
+import TimeAgo from "javascript-time-ago";
+import en from "javascript-time-ago/locale/en";
 import { fetchStreams } from "../../actions/streams";
 
 class ListStreams extends Component {
@@ -10,8 +12,6 @@ class ListStreams extends Component {
   }
 
   render() {
-    const streams = this.props.streams.streams;
-
     if (![undefined, ""].includes(this.props.streams.errorMessage)) {
       return (
         <div className="container">
@@ -24,6 +24,13 @@ class ListStreams extends Component {
         </div>
       );
     }
+
+    const streams = this.props.streams.streams.sort(
+      (a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt)
+    );
+
+    TimeAgo.addDefaultLocale(en);
+    const timeAgo = new TimeAgo("en-US");
 
     return (
       <div className="container">
@@ -81,7 +88,18 @@ class ListStreams extends Component {
                         {stream.uuid}
                       </small>
                     </div>
-                    <small>{stream.spec.kafka["bootstrap.servers"]}</small>
+                    <div className="d-flex w-100 justify-content-between mb-1">
+                      <small className="d-flex-align-items-center">
+                        {stream.spec.kafka["bootstrap.servers"]}
+                      </small>
+                      {stream.updatedAt !== undefined &&
+                        !isNaN(Date.parse(stream.updatedAt)) && (
+                          <small className="d-flex align-items-center text-muted">
+                            Last modified:{" "}
+                            {timeAgo.format(new Date(stream.updatedAt))}
+                          </small>
+                        )}
+                    </div>
                   </a>
                 ))}
               </div>

--- a/ui/src/scss/grid.scss
+++ b/ui/src/scss/grid.scss
@@ -26,9 +26,7 @@ $row-hovered-background-color: #f5f5f5;
     .#{$table-prefix} {
       &-container {
         /* screen width - context bar width + border */
-        width: calc(
-          100vw - var(--datacater-context-bar-width-large-screen)
-        );
+        width: calc(100vw - var(--datacater-context-bar-width-large-screen));
       }
     }
   }


### PR DESCRIPTION
In the UI, sort resources by their `updatedAt`field, showing the most recently updated resources first in the list.

This helps users to navigate their resources in a more transparent way, since names and UUIDs are sometimes not enough for differentiating different resources.

We now also show the update time in the UI:

![Screenshot 2022-12-16 at 10 05 36](https://user-images.githubusercontent.com/128683/208065096-ab0cfe50-7385-48e0-80fe-2ef0c33e9703.png)
