### PR TITLE
feat(ci): Build images for prereleases

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -121,7 +121,7 @@ jobs:
           cp -R $FILTERS_SRC $DEST
           cp -R $TRANSFORM_SRC $DEST
     -   name: Push datacater/datacater to Docker Hub
-        if: github.event.action == 'released'
+        if: github.event.action == 'released' || github.event.action == 'prereleased'
         run: |
           ./gradlew :platform-api:build --no-daemon -x test \
                 -Dquarkus.jib.platforms=linux/amd64,linux/arm64 \
@@ -156,7 +156,7 @@ jobs:
           cp -R $FILTERS_SRC $DEST
           cp -R $TRANSFORM_SRC $DEST
     -   name: Push datacater/pipeline to Docker Hub
-        if: github.event.action == 'released'
+        if: github.event.action == 'released' || github.event.action == 'prereleased'
         run: |
           ./gradlew :pipeline:build --no-daemon -x test \
                 -Dquarkus.jib.platforms=linux/amd64,linux/arm64 \
@@ -191,10 +191,10 @@ jobs:
           cp -R $FILTERS_SRC $DEST
           cp -R $TRANSFORM_SRC $DEST
     -   name: Push datacater/pipeline to Docker Hub
-        if: github.event.action == 'released'
+        if: github.event.action == 'released' || github.event.action == 'prereleased'
         run: |
           ./gradlew :pipeline:build --no-daemon -x test \
-                -Dquarkus.jib.platforms=linux/amd64 \
+                -Dquarkus.jib.platforms=linux/amd64,linux/arm64 \
                 -Dquarkus.native.container-build=true \
                 -Dquarkus.package.type=native \
                 -Dquarkus.container-image.tag=native-${RELEASE_VERSION} \
@@ -225,7 +225,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
     -   name: Build image and push it to DockerHub
         working-directory: python-runner
-        if: github.event.action == 'released'
+        if: github.event.action == 'released' || github.event.action == 'prereleased'
         run: |
           docker build -t datacater/python-runner:${RELEASE_VERSION} .
           docker push datacater/python-runner:${RELEASE_VERSION}
@@ -257,6 +257,6 @@ jobs:
         run: npm run build --if-present
     -   name: Build image and push it to DockerHub
         working-directory: ui
-        if: github.event.action == 'released'
+        if: github.event.action == 'released' || github.event.action == 'prereleased'
         run: |
           docker buildx build --platform=linux/amd64,linux/arm64 -t datacater/ui:${RELEASE_VERSION} --push .


### PR DESCRIPTION
In addition to regular releases, build images also for prereleases.

This allows us to separate main releases, which are published at a low frequency, from nightly releases, which are published at a high frequency.