### PR TITLE
Pass stream configs as environment variables to pipelines

### DIFF
--- a/pipeline/src/main/java/io/datacater/KafkaConfig.java
+++ b/pipeline/src/main/java/io/datacater/KafkaConfig.java
@@ -14,48 +14,28 @@ import java.util.Map;
 
 public class KafkaConfig {
     static private final String errorMsg= "The given Kafka Configuration could not be mapped: %s";
-    static final String DATACATER_STREAMIN_CONFIG =
+    static final String KEY_DESERIALIZER =
             ConfigProvider.getConfig()
-                    .getOptionalValue("datacater.streamin.config", String.class)
-                    .orElse( "{\"key.deserializer\": \"io.datacater.core.serde.JsonDeserializer\", \"value.deserializer\": \"io.datacater.core.serde.JsonDeserializer\"}");
-
+                    .getOptionalValue("datacater.serde.key.deserializer", String.class)
+                    .orElse("io.datacater.core.serde.JsonDeserializer");
+    static final String VALUE_DESERIALIZER =
+            ConfigProvider.getConfig()
+                    .getOptionalValue("datacater.serde.value.deserializer", String.class)
+                    .orElse("io.datacater.core.serde.JsonDeserializer");
+    static final String KEY_SERIALIZER =
+            ConfigProvider.getConfig()
+                    .getOptionalValue("datacater.serde.key.serializer", String.class)
+                    .orElse("io.datacater.core.serde.JsonSerializer");
+    static final String VALUE_SERIALIZER =
+            ConfigProvider.getConfig()
+                    .getOptionalValue("datacater.serde.value.serializer", String.class)
+                    .orElse("io.datacater.core.serde.JsonSerializer");
     static final String DATACATER_STREAMIN_TOPIC =
             ConfigProvider.getConfig()
                     .getOptionalValue("mp.messaging.incoming.streamin.topic", String.class)
                     .orElse("streamin");
-
     static final String DATACATER_STREAMOUT_TOPIC =
             ConfigProvider.getConfig()
                     .getOptionalValue("mp.messaging.incoming.streamout.topic", String.class)
                     .orElse("streamout");
-
-    static final String DATACATER_STREAMOUT_CONFIG =
-            ConfigProvider.getConfig()
-                    .getOptionalValue("datacater.streamout.config", String.class)
-                    .orElse("{\"key.serializer\": \"io.datacater.core.serde.JsonSerializer\", \"value.serializer\": \"io.datacater.core.serde.JsonSerializer\"}");
-
-    @Produces
-    @ApplicationScoped
-    @Identifier("streamin-configuration")
-    public static Map<String, Object> streamInConfig() {
-        return mapConfig(DATACATER_STREAMIN_CONFIG);
-    }
-
-    @Produces
-    @ApplicationScoped
-    @Identifier("streamout-configuration")
-    public static Map<String, Object> streamOutConfig() {
-        return mapConfig(DATACATER_STREAMOUT_CONFIG);
-    }
-
-    private static Map<String, Object> mapConfig(String json){
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String, Object> map;
-        try{
-            map = mapper.readValue(json, new TypeReference<>(){});
-        } catch (JsonProcessingException e){
-            throw new KafkaConfigurationException(String.format(errorMsg, e.getMessage()));
-        }
-        return map;
-    }
 }

--- a/pipeline/src/main/java/io/datacater/KafkaConfig.java
+++ b/pipeline/src/main/java/io/datacater/KafkaConfig.java
@@ -16,34 +16,34 @@ public class KafkaConfig {
     static private final String errorMsg= "The given Kafka Configuration could not be mapped: %s";
     static final String DATACATER_STREAMIN_CONFIG =
             ConfigProvider.getConfig()
-                    .getOptionalValue("datacater.stream-in.config", String.class)
+                    .getOptionalValue("datacater.streamin.config", String.class)
                     .orElse( "{\"key.deserializer\": \"io.datacater.core.serde.JsonDeserializer\", \"value.deserializer\": \"io.datacater.core.serde.JsonDeserializer\"}");
 
     static final String DATACATER_STREAMIN_TOPIC =
             ConfigProvider.getConfig()
-                    .getOptionalValue("mp.messaging.incoming.stream-in.topic", String.class)
-                    .orElse("stream-in");
+                    .getOptionalValue("mp.messaging.incoming.streamin.topic", String.class)
+                    .orElse("streamin");
 
     static final String DATACATER_STREAMOUT_TOPIC =
             ConfigProvider.getConfig()
-                    .getOptionalValue("mp.messaging.incoming.stream-out.topic", String.class)
-                    .orElse("stream-out");
+                    .getOptionalValue("mp.messaging.incoming.streamout.topic", String.class)
+                    .orElse("streamout");
 
     static final String DATACATER_STREAMOUT_CONFIG =
             ConfigProvider.getConfig()
-                    .getOptionalValue("datacater.stream-out.config", String.class)
+                    .getOptionalValue("datacater.streamout.config", String.class)
                     .orElse("{\"key.serializer\": \"io.datacater.core.serde.JsonSerializer\", \"value.serializer\": \"io.datacater.core.serde.JsonSerializer\"}");
 
     @Produces
     @ApplicationScoped
-    @Identifier("stream-in-configuration")
+    @Identifier("streamin-configuration")
     public static Map<String, Object> streamInConfig() {
         return mapConfig(DATACATER_STREAMIN_CONFIG);
     }
 
     @Produces
     @ApplicationScoped
-    @Identifier("stream-out-configuration")
+    @Identifier("streamout-configuration")
     public static Map<String, Object> streamOutConfig() {
         return mapConfig(DATACATER_STREAMOUT_CONFIG);
     }

--- a/pipeline/src/main/java/io/datacater/Pipeline.java
+++ b/pipeline/src/main/java/io/datacater/Pipeline.java
@@ -15,7 +15,6 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.time.Duration;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import java.net.ConnectException;
 import java.util.UUID;
 import java.util.concurrent.CompletionException;
 
@@ -58,11 +57,11 @@ public class Pipeline {
   }
 
   @Inject
-  @Channel(PipelineConfig.STREAM_OUT)
+  @Channel(PipelineConfig.STREAMOUT)
   @OnOverflow(value = OnOverflow.Strategy.UNBOUNDED_BUFFER)
   Emitter<Record<byte[], byte[]>> producer;
 
-  @Incoming(PipelineConfig.STREAM_IN)
+  @Incoming(PipelineConfig.STREAMIN)
   @Blocking
   @Acknowledgment(Acknowledgment.Strategy.POST_PROCESSING)
   public void processUUID(ConsumerRecords<byte[], byte[]> messages) {

--- a/pipeline/src/main/java/io/datacater/Pipeline.java
+++ b/pipeline/src/main/java/io/datacater/Pipeline.java
@@ -37,17 +37,13 @@ public class Pipeline {
   private String host;
   private Integer port;
 
-  private Deserializer keyDeserializer =
-          Deserializers.deserializers.get(KafkaConfig.streamInConfig().get("key.deserializer").toString());
+  private Deserializer keyDeserializer = Deserializers.deserializers.get(KafkaConfig.KEY_DESERIALIZER);
 
-  private Deserializer valueDeserializer =
-          Deserializers.deserializers.get(KafkaConfig.streamInConfig().get("value.deserializer").toString());
+  private Deserializer valueDeserializer = Deserializers.deserializers.get(KafkaConfig.VALUE_DESERIALIZER);
 
-  private Serializer keySerializer =
-          Serializers.serializers.get(KafkaConfig.streamOutConfig().get("key.serializer").toString());
+  private Serializer keySerializer = Serializers.serializers.get(KafkaConfig.KEY_SERIALIZER);
 
-  private Serializer valueSerializer =
-          Serializers.serializers.get(KafkaConfig.streamOutConfig().get("value.serializer").toString());
+  private Serializer valueSerializer = Serializers.serializers.get(KafkaConfig.VALUE_SERIALIZER);
 
   WebClient client;
 

--- a/pipeline/src/main/java/io/datacater/PipelineConfig.java
+++ b/pipeline/src/main/java/io/datacater/PipelineConfig.java
@@ -29,8 +29,8 @@ public class PipelineConfig {
                     .getOptionalValue("datacater.python-runner.protocol", String.class)
                     .orElse("file");
 
-    static final String STREAM_IN = "stream-in";
-    static final String STREAM_OUT = "stream-out";
+    static final String STREAMIN = "streamin";
+    static final String STREAMOUT = "streamout";
     static final String FILE_ENDPOINT = "/batch-file";
     static final String HTTP_ENDPOINT = "/batch";
     static final String HEADER = "Content-Type";

--- a/pipeline/src/main/resources/application.yml
+++ b/pipeline/src/main/resources/application.yml
@@ -20,7 +20,6 @@ mp       :
       streamout:
         merge: true
         connector: smallrye-kafka
-        kafka-configuration: streamout-configuration
         topic: streamout
     incoming:
       streamin:
@@ -29,7 +28,6 @@ mp       :
         max:
           poll:
             records: ${datacater.message.batch.size}
-        kafka-configuration: streamin-configuration
         topic: streamin
 datacater:
   python-runner:

--- a/pipeline/src/main/resources/application.yml
+++ b/pipeline/src/main/resources/application.yml
@@ -72,13 +72,13 @@ datacater:
   mp:
     messaging:
       outgoing:
-        stream-in-test:
+        streamin-test:
           connector: smallrye-kafka
-          topic: stream-in
+          topic: streamin
       incoming:
-        stream-out-test:
+        streamout-test:
           connector: smallrye-kafka
-          topic: stream-out
+          topic: streamout
           key:
             deserializer: io.datacater.core.serde.JsonDeserializer
           value:

--- a/pipeline/src/main/resources/application.yml
+++ b/pipeline/src/main/resources/application.yml
@@ -17,20 +17,20 @@ quarkus  :
 mp       :
   messaging:
     outgoing:
-      stream-out:
+      streamout:
         merge: true
         connector: smallrye-kafka
-        kafka-configuration: stream-out-configuration
-        topic: stream-out
+        kafka-configuration: streamout-configuration
+        topic: streamout
     incoming:
-      stream-in:
+      streamin:
         batch: true
         connector: smallrye-kafka
         max:
           poll:
             records: ${datacater.message.batch.size}
-        kafka-configuration: stream-in-configuration
-        topic: stream-in
+        kafka-configuration: streamin-configuration
+        topic: streamin
 datacater:
   python-runner:
     port: 50000
@@ -40,9 +40,9 @@ datacater:
   message:
     batch:
       size: 2500
-  stream-in:
+  streamin:
     config: '{"key.deserializer": "io.datacater.core.serde.JsonDeserializer", "value.deserializer": "io.datacater.core.serde.JsonDeserializer"}'
-  stream-out:
+  streamout:
     config: '{"key.serializer": "io.datacater.core.serde.JsonSerializer", "value.serializer": "io.datacater.core.serde.JsonSerializer"}'
 
 

--- a/pipeline/src/main/resources/application.yml
+++ b/pipeline/src/main/resources/application.yml
@@ -38,11 +38,6 @@ datacater:
   message:
     batch:
       size: 2500
-  streamin:
-    config: '{"key.deserializer": "io.datacater.core.serde.JsonDeserializer", "value.deserializer": "io.datacater.core.serde.JsonDeserializer"}'
-  streamout:
-    config: '{"key.serializer": "io.datacater.core.serde.JsonSerializer", "value.serializer": "io.datacater.core.serde.JsonSerializer"}'
-
 
 '%dev'   :
   quarkus:

--- a/pipeline/src/test/java/io/datacater/PipelineTest.java
+++ b/pipeline/src/test/java/io/datacater/PipelineTest.java
@@ -79,7 +79,7 @@ class PipelineTest {
             message.put("email", "max-mustermann@datacater.io");
             message.put("is_admin", "true");
             producer.send(new ProducerRecord<>(
-                    "stream-in",
+                    "streamin",
                     new JsonObject().put("value", UUID.randomUUID()),
                     message.put("number", i)));
         }
@@ -88,7 +88,7 @@ class PipelineTest {
         message.put("email", "max-mustermann@datacater.io");
         message.put("is_admin", "true");
         CompletionStage<Void> messageToWaitOn = producer.send(new ProducerRecord<>(
-                "stream-in",
+                "streamin",
                 new JsonObject().put("value", UUID.randomUUID()),
                 message));
 

--- a/pipeline/src/test/java/io/datacater/PipelineTest.java
+++ b/pipeline/src/test/java/io/datacater/PipelineTest.java
@@ -11,7 +11,6 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.reactive.messaging.*;
 import org.jboss.logging.Logger;
-import org.junit.Ignore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
@@ -31,13 +30,13 @@ import static org.junit.jupiter.api.Assertions.*;
 @QuarkusTestResource(KafkaCompanionResource.class)
 class PipelineTest {
     private static final Logger LOGGER = Logger.getLogger(PipelineTest.class);
-    private static final String STREAM_IN = "stream-in-test";
-    private static final String STREAM_OUT = "stream-out";
+    private static final String STREAMIN = "streamin-test";
+    private static final String STREAMOUT = "streamout";
     @Inject
     Pipeline application;
 
     @Inject
-    @Channel(STREAM_IN)
+    @Channel(STREAMIN)
     Emitter<ProducerRecord<JsonObject, JsonObject>> producer;
 
     @InjectKafkaCompanion
@@ -99,7 +98,7 @@ class PipelineTest {
                 .consumeWithDeserializers(
                         io.datacater.core.serde.JsonDeserializer.class,
                         io.datacater.core.serde.JsonDeserializer.class)
-                .fromTopics(STREAM_OUT,1)
+                .fromTopics(STREAMOUT,1)
                 .awaitCompletion();
         assertTrue(messages.getFirstRecord().value().toString().contains("max-mustermann@datacater.io"));
         assertEquals(1, messages.count());

--- a/platform-api/src/main/java/io/datacater/core/deployment/K8Deployment.java
+++ b/platform-api/src/main/java/io/datacater/core/deployment/K8Deployment.java
@@ -322,21 +322,6 @@ public class K8Deployment {
     variables.add(createEnvVariable(StaticConfig.STREAMIN_CONFIG_NAME, streamIn.getName()));
     variables.add(createEnvVariable(StaticConfig.STREAMOUT_CONFIG_NAME, streamOut.getName()));
 
-    variables.add(createEnvVariable("MP_MESSAGING_INCOMING_STREAMIN_CONNECTOR", "smallrye-kafka"));
-    variables.add(createEnvVariable("MP_MESSAGING_INCOMING_STREAMIN_TOPIC", streamIn.getName()));
-    variables.add(
-        createEnvVariable(
-            "MP_MESSAGING_INCOMING_STREAMIN_BOOTSTRAP_SERVERS",
-            "pkc-75m1o.europe-west3.gcp.confluent.cloud:9092"));
-    variables.add(
-        createEnvVariable(
-            "MP_MESSAGING_INCOMING_STREAMIN_VALUE_DESERIALIZER",
-            "org.apache.kafka.common.serialization.StringDeserializer"));
-    variables.add(
-        createEnvVariable(
-            "MP_MESSAGING_INCOMING_STREAMIN_KEY_DESERIALIZER",
-            "org.apache.kafka.common.serialization.StringDeserializer"));
-
     try {
       variables.add(
           createEnvVariable(

--- a/platform-api/src/main/java/io/datacater/core/deployment/K8Deployment.java
+++ b/platform-api/src/main/java/io/datacater/core/deployment/K8Deployment.java
@@ -319,8 +319,23 @@ public class K8Deployment {
         getEnvVariableFromNode(streamOut.getSpec(), StaticConfig.VALUE_SERIALIZER));
 
     List<EnvVar> variables = new ArrayList<>();
-    variables.add(createEnvVariable(StaticConfig.STREAM_IN_CONFIG_NAME, streamIn.getName()));
-    variables.add(createEnvVariable(StaticConfig.STREAM_OUT_CONFIG_NAME, streamOut.getName()));
+    variables.add(createEnvVariable(StaticConfig.STREAMIN_CONFIG_NAME, streamIn.getName()));
+    variables.add(createEnvVariable(StaticConfig.STREAMOUT_CONFIG_NAME, streamOut.getName()));
+
+    variables.add(createEnvVariable("MP_MESSAGING_INCOMING_STREAMIN_CONNECTOR", "smallrye-kafka"));
+    variables.add(createEnvVariable("MP_MESSAGING_INCOMING_STREAMIN_TOPIC", streamIn.getName()));
+    variables.add(
+        createEnvVariable(
+            "MP_MESSAGING_INCOMING_STREAMIN_BOOTSTRAP_SERVERS",
+            "pkc-75m1o.europe-west3.gcp.confluent.cloud:9092"));
+    variables.add(
+        createEnvVariable(
+            "MP_MESSAGING_INCOMING_STREAMIN_VALUE_DESERIALIZER",
+            "org.apache.kafka.common.serialization.StringDeserializer"));
+    variables.add(
+        createEnvVariable(
+            "MP_MESSAGING_INCOMING_STREAMIN_KEY_DESERIALIZER",
+            "org.apache.kafka.common.serialization.StringDeserializer"));
 
     try {
       variables.add(

--- a/platform-api/src/main/java/io/datacater/core/deployment/K8Deployment.java
+++ b/platform-api/src/main/java/io/datacater/core/deployment/K8Deployment.java
@@ -324,15 +324,12 @@ public class K8Deployment {
         getEnvVariableFromNode(streamOut.getSpec(), StaticConfig.VALUE_SERIALIZER));
 
     // Store Serde-related information
-    Map<String, Object> dataCaterConfig = new HashMap<>();
-    dataCaterConfig.put(
-        StaticConfig.KEY_DESERIALIZER, streamInConfig.get(StaticConfig.KEY_DESERIALIZER));
-    dataCaterConfig.put(
-        StaticConfig.VALUE_DESERIALIZER, streamInConfig.get(StaticConfig.VALUE_DESERIALIZER));
-    dataCaterConfig.put(
-        StaticConfig.KEY_SERIALIZER, streamOutConfig.get(StaticConfig.KEY_SERIALIZER));
-    dataCaterConfig.put(
-        StaticConfig.VALUE_SERIALIZER, streamOutConfig.get(StaticConfig.VALUE_SERIALIZER));
+    Map<String, Object> dataCaterConfig =
+        Map.of(
+            StaticConfig.KEY_DESERIALIZER, streamInConfig.get(StaticConfig.KEY_DESERIALIZER),
+            StaticConfig.VALUE_DESERIALIZER, streamInConfig.get(StaticConfig.VALUE_DESERIALIZER),
+            StaticConfig.KEY_SERIALIZER, streamOutConfig.get(StaticConfig.KEY_SERIALIZER),
+            StaticConfig.VALUE_SERIALIZER, streamOutConfig.get(StaticConfig.VALUE_SERIALIZER));
 
     // Remove Serde-related information from channel configs
     streamInConfig.remove(StaticConfig.KEY_DESERIALIZER);

--- a/platform-api/src/main/java/io/datacater/core/deployment/K8Deployment.java
+++ b/platform-api/src/main/java/io/datacater/core/deployment/K8Deployment.java
@@ -338,8 +338,8 @@ public class K8Deployment {
     streamOutConfig.remove(StaticConfig.VALUE_SERIALIZER);
 
     /**
-     * Set `group.id` to the UUID of the deployment, if absent, such that deployments with more than one
-     * replica can make use of Apache Kafka's consumer group protocol.
+     * Set `group.id` to the UUID of the deployment, if absent, such that deployments with more than
+     * one replica can make use of Apache Kafka's consumer group protocol.
      */
     streamInConfig.putIfAbsent(StaticConfig.GROUP_ID, uuid);
 

--- a/platform-api/src/main/java/io/datacater/core/deployment/StaticConfig.java
+++ b/platform-api/src/main/java/io/datacater/core/deployment/StaticConfig.java
@@ -9,6 +9,7 @@ public class StaticConfig {
 
   static final String STREAMIN_ENV_PREFIX = "MP_MESSAGING_INCOMING_STREAMIN_";
   static final String STREAMOUT_ENV_PREFIX = "MP_MESSAGING_OUTGOING_STREAMOUT_";
+  static final String DATACATER_SERDE_ENV_PREFIX = "DATACATER_SERDE_";
   static final String DATACATER_PIPELINE = "datacater-pipeline";
   static final String PYTHON_RUNNER_NAME = "python-runner";
   static final String APP = "datacater.io/app";

--- a/platform-api/src/main/java/io/datacater/core/deployment/StaticConfig.java
+++ b/platform-api/src/main/java/io/datacater/core/deployment/StaticConfig.java
@@ -7,8 +7,8 @@ import org.eclipse.microprofile.config.ConfigProvider;
 public class StaticConfig {
   private StaticConfig() {}
 
-  static final String STREAMIN_CONFIG_NAME = "MP_MESSAGING_INCOMING_STREAMIN_TOPIC";
-  static final String STREAMOUT_CONFIG_NAME = "MP_MESSAGING_OUTGOING_STREAMOUT_TOPIC";
+  static final String STREAMIN_ENV_PREFIX = "MP_MESSAGING_INCOMING_STREAMIN_";
+  static final String STREAMOUT_ENV_PREFIX = "MP_MESSAGING_OUTGOING_STREAMOUT_";
   static final String DATACATER_PIPELINE = "datacater-pipeline";
   static final String PYTHON_RUNNER_NAME = "python-runner";
   static final String APP = "datacater.io/app";

--- a/platform-api/src/main/java/io/datacater/core/deployment/StaticConfig.java
+++ b/platform-api/src/main/java/io/datacater/core/deployment/StaticConfig.java
@@ -7,8 +7,8 @@ import org.eclipse.microprofile.config.ConfigProvider;
 public class StaticConfig {
   private StaticConfig() {}
 
-  static final String STREAM_IN_CONFIG_NAME = "MP_MESSAGING_INCOMING_STREAM_IN_TOPIC";
-  static final String STREAM_OUT_CONFIG_NAME = "MP_MESSAGING_OUTGOING_STREAM_OUT_TOPIC";
+  static final String STREAMIN_CONFIG_NAME = "MP_MESSAGING_INCOMING_STREAMIN_TOPIC";
+  static final String STREAMOUT_CONFIG_NAME = "MP_MESSAGING_OUTGOING_STREAMOUT_TOPIC";
   static final String DATACATER_PIPELINE = "datacater-pipeline";
   static final String PYTHON_RUNNER_NAME = "python-runner";
   static final String APP = "datacater.io/app";
@@ -51,8 +51,8 @@ public class StaticConfig {
   static final String VALUE_SERIALIZER = "value.serializer";
   static final String STREAMIN_CONFIG_TEXT = "stream-in-config";
   static final String STREAMOUT_CONFIG_TEXT = "stream-out-config";
-  static final String DC_STREAMIN_CONFIG_TEXT = "DATACATER_STREAM_IN_CONFIG";
-  static final String DC_STREAMOUT_CONFIG_TEXT = "DATACATER_STREAM_OUT_CONFIG";
+  static final String DC_STREAMIN_CONFIG_TEXT = "DATACATER_STREAMIN_CONFIG";
+  static final String DC_STREAMOUT_CONFIG_TEXT = "DATACATER_STREAM_OUTCONFIG";
   static final String HTTP = "http";
   static final String CONDITIONS = "Conditions";
   static final String ERROR_TAG = "error";
@@ -117,8 +117,8 @@ public class StaticConfig {
   static class LoggerMessages {
     private LoggerMessages() {}
 
-    static final String DEPLOYMENT_DELETED = "DatacaterDeployment deleted successfully: %s";
-    static final String DEPLOYMENT_NOT_DELETED = "DatacaterDeployment could not be deleted: %s";
+    static final String DEPLOYMENT_DELETED = "Datacater Deployment deleted successfully: %s";
+    static final String DEPLOYMENT_NOT_DELETED = "Datacater Deployment could not be deleted: %s";
     static final String PIPELINE_NOT_FOUND = "The referenced Pipeline UUID could not be found";
     static final String STREAM_NOT_FOUND = "The referenced %s UUID could not be found";
     static final String DEPLOYMENT_NOT_FOUND = "The referenced Deployment could not be found.";


### PR DESCRIPTION
We cannot use Smallrye's kafka-configuration option for passing channel configs to pipelines that are running in the native mode.

To support native mode, this PR introduces the usage of environment variables for configuring streams/channels of the pipeline.