### PR TITLE
feat(streams): Allow users to overwrite the `group.id` of deployments

### DIFF
--- a/platform-api/src/main/java/io/datacater/core/deployment/K8Deployment.java
+++ b/platform-api/src/main/java/io/datacater/core/deployment/K8Deployment.java
@@ -306,7 +306,10 @@ public class K8Deployment {
     streamInConfig.putIfAbsent(
         StaticConfig.VALUE_DESERIALIZER,
         getEnvVariableFromNode(streamIn.getSpec(), StaticConfig.VALUE_DESERIALIZER));
-    streamInConfig.put(StaticConfig.GROUP_ID, uuid);
+
+    // Set consumer group id to UUID of deployment, if absent
+    // This makes sure that multiple instances of the same deployment end up in the same consumer group
+    streamInConfig.putIfAbsent(StaticConfig.GROUP_ID, uuid);
 
     streamOutConfig.putIfAbsent(
         StaticConfig.BOOTSTRAP_SERVERS,

--- a/ui/src/containers/streams/EditStream.js
+++ b/ui/src/containers/streams/EditStream.js
@@ -520,13 +520,6 @@ class EditStream extends Component {
                 />
               </div>
             ))}
-            {this.state.stream.spec.kafka["group.id"] !== undefined && (
-              <div className="col-12 mt-4 alert alert-warning">
-                Setting the consumer property <i>group.id</i> does not have any
-                impact because DataCater overwrites it with the Deployment's
-                UUID.
-              </div>
-            )}
             <div className="col-12 mt-3">
               <h6 className="d-inline me-2">Add config</h6>
               <span className="text-muted fs-7">

--- a/ui/src/containers/streams/NewStream.js
+++ b/ui/src/containers/streams/NewStream.js
@@ -500,13 +500,6 @@ class NewStream extends Component {
                 />
               </div>
             ))}
-            {this.state.stream.spec.kafka["group.id"] !== undefined && (
-              <div className="col-12 mt-4 alert alert-warning">
-                Setting the consumer property <i>group.id</i> does not have any
-                impact because DataCater overwrites it with the Deployment's
-                UUID.
-              </div>
-            )}
             <div className="col-12 mt-3">
               <h6 className="d-inline me-2">Add config</h6>
               <span className="text-muted fs-7">


### PR DESCRIPTION
This PR allows users to define a custom consumer group id (using the consumer API property `group.id`), while still keeping the deployment's UUID as the default consumer group id.