### PR TITLE
fix(ui): Highlight filters

### DIFF
--- a/ui/src/components/pipelines/PipelineDesigner.js
+++ b/ui/src/components/pipelines/PipelineDesigner.js
@@ -131,6 +131,7 @@ class PipelineDesigner extends Component {
           hideStepNameFormFunc={this.props.hideStepNameFormFunc}
           pipeline={pipeline}
           editColumnFunc={this.props.editColumnFunc}
+          filters={this.props.filters}
           sampleRecords={this.props.sampleRecords}
           showGrid={this.state.showGrid}
           showStepNameForm={this.props.showStepNameForm}

--- a/ui/src/components/pipelines/pipeline_designer/grid/TableHeaderCell.js
+++ b/ui/src/components/pipelines/pipeline_designer/grid/TableHeaderCell.js
@@ -59,8 +59,8 @@ class TableHeaderCell extends Component {
     } = this.props.column;
 
     let sampleCellClassNames = "sample-cell py-2 ps-0";
-    let transformation = undefined;
 
+    let transformation = undefined;
     if (
       currentStep >= 0 &&
       step.fields !== undefined &&
@@ -70,6 +70,19 @@ class TableHeaderCell extends Component {
       const transformationKey = step.fields[field.name].transform.key;
       transformation = this.props.column.transforms.find(
         (transformation) => transformation.key === transformationKey
+      );
+    }
+
+    let filter = undefined;
+    if (
+      currentStep >= 0 &&
+      step.fields !== undefined &&
+      step.fields[field.name] !== undefined &&
+      step.fields[field.name].filter !== undefined
+    ) {
+      const filterKey = step.fields[field.name].filter.key;
+      filter = this.props.column.filters.find(
+        (filter) => filter.key === filterKey
       );
     }
 
@@ -93,7 +106,8 @@ class TableHeaderCell extends Component {
           </div>
           {step !== undefined &&
             step.kind === "Field" &&
-            transformation == null && (
+            transformation === undefined &&
+            filter === undefined && (
               <Button
                 variant="white"
                 size="sm"
@@ -106,7 +120,7 @@ class TableHeaderCell extends Component {
             )}
           {step !== undefined &&
             step.kind === "Field" &&
-            transformation != null && (
+            (transformation !== undefined || filter !== undefined) && (
               <Button
                 variant="primary"
                 size="sm"
@@ -114,7 +128,9 @@ class TableHeaderCell extends Component {
                 onClick={(event) => this.openContextBar(field)}
               >
                 <Package className="feather-icon me-2" />
-                {transformation.name}
+                {transformation !== undefined &&
+                  `Transform: ${transformation.name}`}
+                {transformation === undefined && `Filter: ${filter.name}`}
               </Button>
             )}
         </div>

--- a/ui/src/components/pipelines/pipeline_designer/grid/Toolbar.js
+++ b/ui/src/components/pipelines/pipeline_designer/grid/Toolbar.js
@@ -35,6 +35,16 @@ class Toolbar extends Component {
       );
     }
 
+    let filter = undefined;
+    if (
+      step !== undefined &&
+      step.kind === "Record" &&
+      step.filter !== undefined
+    ) {
+      const filterKey = step.filter.key;
+      filter = this.props.filters.find((filter) => filter.key === filterKey);
+    }
+
     return (
       <div className="container mb-2">
         <div className="row align-items-center">
@@ -75,7 +85,8 @@ class Toolbar extends Component {
           <div className="col d-flex align-items-center justify-content-end">
             {step !== undefined &&
               step.kind === "Record" &&
-              transformation === undefined && (
+              transformation === undefined &&
+              filter === undefined && (
                 <button
                   onClick={(e) => {
                     this.props.editColumnFunc();
@@ -88,7 +99,7 @@ class Toolbar extends Component {
               )}
             {step !== undefined &&
               step.kind === "Record" &&
-              transformation !== undefined && (
+              (transformation !== undefined || filter !== undefined) && (
                 <button
                   onClick={(e) => {
                     this.props.editColumnFunc();
@@ -96,7 +107,8 @@ class Toolbar extends Component {
                   className="btn btn-primary text-white btn-sm me-4"
                 >
                   <Package className="feather-icon me-2" />
-                  {transformation.name}
+                  {transformation !== undefined && transformation.name}
+                  {transformation === undefined && filter.name}
                 </button>
               )}
             {step !== undefined && (


### PR DESCRIPTION
If a pipeline step only defines a filter but no transform, highlight its name in the grid view.
This helps users to quickly navigate pipelines.

Before:

<img width="1624" alt="Screenshot 2022-12-20 at 20 39 30" src="https://user-images.githubusercontent.com/128683/208752936-bc143f9a-ce21-4a65-88a2-783859f649ba.png">

After:

<img width="1624" alt="Screenshot 2022-12-20 at 20 39 52" src="https://user-images.githubusercontent.com/128683/208753001-3b1223b0-81ee-40b4-81f8-0d00aa3c3ce9.png">
