### PR TITLE
fix(ui): Close sidebar correctly when resetting transform

### DIFF
--- a/ui/src/containers/pipelines/EditPipeline.js
+++ b/ui/src/containers/pipelines/EditPipeline.js
@@ -268,6 +268,7 @@ class EditPipeline extends Component {
           delete step.transform;
           pipeline.spec.steps[currentStep - 1] = step;
           editColumn = undefined;
+          contextBarActive = false;
         } else {
           pipeline.spec.steps[currentStep - 1]["transform"] = {
             key: value,
@@ -279,6 +280,7 @@ class EditPipeline extends Component {
           delete step.filter;
           pipeline.spec.steps[currentStep - 1] = step;
           editColumn = undefined;
+          contextBarActive = false;
         } else {
           pipeline.spec.steps[currentStep - 1]["filter"] = {
             key: value,
@@ -310,6 +312,7 @@ class EditPipeline extends Component {
           }
           pipeline.spec.steps[currentStep - 1] = step;
           editColumn = undefined;
+          contextBarActive = false;
         } else {
           pipeline.spec.steps[currentStep - 1].fields[fieldName]["transform"] =
             {
@@ -326,6 +329,7 @@ class EditPipeline extends Component {
           }
           pipeline.spec.steps[currentStep - 1] = step;
           editColumn = undefined;
+          contextBarActive = false;
         } else {
           pipeline.spec.steps[currentStep - 1].fields[fieldName]["filter"] = {
             key: value,


### PR DESCRIPTION
When resetting a transform or filter, close the sidebar correctly and do not leave an empty area.

The _empty area_ is clearly visible on the following screenshot:

<img width="1624" alt="Screenshot 2022-12-20 at 20 52 30" src="https://user-images.githubusercontent.com/128683/208754853-b8d1aad0-7ac8-4ed3-b9bf-ceccce46eef3.png">
