### PR TITLE
feat(ui/pipeline-designer): Allow changing sample size

### DIFF
--- a/ui/src/components/pipelines/PipelineDesigner.js
+++ b/ui/src/components/pipelines/PipelineDesigner.js
@@ -131,6 +131,7 @@ class PipelineDesigner extends Component {
           hideStepNameFormFunc={this.props.hideStepNameFormFunc}
           pipeline={pipeline}
           editColumnFunc={this.props.editColumnFunc}
+          inspectLimit={this.props.inspectLimit}
           sampleRecords={this.props.sampleRecords}
           showGrid={this.state.showGrid}
           showStepNameForm={this.props.showStepNameForm}
@@ -138,6 +139,7 @@ class PipelineDesigner extends Component {
           step={step}
           toggleShowGridFunc={this.toggleShowGrid}
           transforms={this.props.transforms}
+          updateInspectLimitFunc={this.props.updateInspectLimitFunc}
           updateStepNameFunc={this.props.updateStepNameFunc}
         />
         {this.state.showGrid && (

--- a/ui/src/components/pipelines/pipeline_designer/grid/Toolbar.js
+++ b/ui/src/components/pipelines/pipeline_designer/grid/Toolbar.js
@@ -5,6 +5,7 @@ class Toolbar extends Component {
   render() {
     const {
       hideStepNameFormFunc,
+      inspectLimit,
       pipeline,
       sampleRecords,
       showGrid,
@@ -12,6 +13,7 @@ class Toolbar extends Component {
       showStepNameFormFunc,
       step,
       toggleShowGridFunc,
+      updateInspectLimitFunc,
       updateStepNameFunc,
     } = this.props;
 
@@ -124,6 +126,16 @@ class Toolbar extends Component {
               </a>
             </div>
             <span className="ms-4">{sampleRecords.length} records</span>
+            <label className="ms-4 me-2 col-form-label">Limit:</label>
+            <input
+              type="text"
+              className="form-control form-control-sm"
+              onChange={updateInspectLimitFunc}
+              aria-describedby="passwordHelpInline"
+              placeholder="100"
+              value={inspectLimit}
+              style={{ width: "75px" }}
+            />
           </div>
         </div>
       </div>

--- a/ui/src/components/pipelines/pipeline_designer/grid/Toolbar.js
+++ b/ui/src/components/pipelines/pipeline_designer/grid/Toolbar.js
@@ -2,6 +2,23 @@ import React, { Component } from "react";
 import { Code, Package, Table } from "react-feather";
 
 class Toolbar extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      tempInspectLimit: undefined,
+    };
+
+    this.updateTempInspectLimit = this.updateTempInspectLimit.bind(this);
+  }
+
+  updateTempInspectLimit(event) {
+    if (!isNaN(event.target.value)) {
+      this.setState({
+        tempInspectLimit: event.target.value,
+      });
+    }
+  }
+
   render() {
     const {
       hideStepNameFormFunc,
@@ -130,10 +147,20 @@ class Toolbar extends Component {
             <input
               type="text"
               className="form-control form-control-sm"
-              onChange={updateInspectLimitFunc}
+              onChange={this.updateTempInspectLimit}
               aria-describedby="passwordHelpInline"
+              onBlur={updateInspectLimitFunc}
+              onKeyDown={(e) => {
+                if (e.which === 13) {
+                  e.target.blur();
+                }
+              }}
               placeholder="100"
-              value={inspectLimit}
+              value={
+                this.state.tempInspectLimit !== undefined
+                  ? this.state.tempInspectLimit
+                  : inspectLimit
+              }
               style={{ width: "75px" }}
             />
           </div>

--- a/ui/src/containers/pipelines/EditPipeline.js
+++ b/ui/src/containers/pipelines/EditPipeline.js
@@ -47,6 +47,7 @@ class EditPipeline extends Component {
       currentStep: undefined,
       debugRecord: undefined,
       errorMessage: "",
+      inspectLimit: 100,
       pipeline: {},
       pipelineUpdated: false,
       pipelineUpdatedAt: undefined,
@@ -75,6 +76,7 @@ class EditPipeline extends Component {
     this.hideStepNameForm = this.hideStepNameForm.bind(this);
     this.openDebugView = this.openDebugView.bind(this);
     this.closeDebugView = this.closeDebugView.bind(this);
+    this.updateInspectLimit = this.updateInspectLimit.bind(this);
   }
 
   componentDidMount() {
@@ -676,6 +678,20 @@ class EditPipeline extends Component {
     });
   }
 
+  updateInspectLimit(event) {
+    const limit = isNaN(parseInt(event.target.value))
+      ? 100
+      : parseInt(event.target.value);
+    this.setState({ inspectLimit: limit });
+    this.props
+      .inspectStream(this.state.pipeline.metadata["stream-in"], limit)
+      .then(() => {
+        if (this.state.currentStep !== undefined) {
+          this.updateSampleRecords(this.state.pipeline, this.state.currentStep);
+        }
+      });
+  }
+
   render() {
     const pipeline = this.state.pipeline;
 
@@ -872,6 +888,7 @@ class EditPipeline extends Component {
             handleStepChangeFunc={this.handleStepChange}
             hideContextBarFunc={this.hideContextBar}
             hideStepNameFormFunc={this.hideStepNameForm}
+            inspectLimit={this.state.inspectLimit}
             moveToStepFunc={this.moveToStep}
             moveStepFunc={this.moveStep}
             openDebugViewFunc={this.openDebugView}
@@ -883,6 +900,7 @@ class EditPipeline extends Component {
             showStepNameForm={this.state.showStepNameForm}
             showStepNameFormFunc={this.showStepNameForm}
             transforms={this.props.transforms.transforms}
+            updateInspectLimitFunc={this.updateInspectLimit}
             updateStepNameFunc={this.updateStepName}
           />
         )}


### PR DESCRIPTION
Allow users to change the size of the sample set in the pipeline designer, which is set to 100 by default.

Use a similar approach as used for the inspection of streams:

![Uploading Screenshot 2022-12-21 at 14.22.00.png…]()
