### PR TITLE
fix(ui): Always show fields that are transformed

### DIFF
--- a/ui/src/containers/pipelines/EditPipeline.js
+++ b/ui/src/containers/pipelines/EditPipeline.js
@@ -837,7 +837,12 @@ class EditPipeline extends Component {
       );
     }
 
-    const profile = profileRecords(sampleRecords);
+    const fields =
+      this.state.currentStep !== undefined
+        ? pipeline.spec.steps[this.state.currentStep - 1].fields || {}
+        : {};
+    const fieldNames = Object.keys(fields);
+    const profile = profileRecords(sampleRecords, fieldNames);
 
     const records = sampleRecords.map(function (sample, index) {
       return Object.assign({}, sample, { id: index + 1 });

--- a/ui/src/containers/pipelines/EditPipeline.js
+++ b/ui/src/containers/pipelines/EditPipeline.js
@@ -837,10 +837,12 @@ class EditPipeline extends Component {
       );
     }
 
+    // Get all fields that define a filter or transform
     const fields =
       this.state.currentStep !== undefined
         ? pipeline.spec.steps[this.state.currentStep - 1].fields || {}
         : {};
+    // Get only the names of the fields
     const fieldNames = Object.keys(fields);
     const profile = profileRecords(sampleRecords, fieldNames);
 

--- a/ui/src/containers/streams/InspectStream.js
+++ b/ui/src/containers/streams/InspectStream.js
@@ -203,7 +203,7 @@ class InspectStream extends Component {
     }
 
     const sampleRecords = this.props.streams.inspectionResult;
-    const profile = profileRecords(sampleRecords);
+    const profile = profileRecords(sampleRecords, []);
 
     const records = sampleRecords.map(function (sample, index) {
       return Object.assign({}, sample["value"], { id: index + 1 });

--- a/ui/src/helpers/profileRecords.js
+++ b/ui/src/helpers/profileRecords.js
@@ -32,7 +32,7 @@ function getDataType(value) {
  * Determine metrics, such as the number of distinct values, the
  * number of  missing values, and the most frequent values.
  */
-export function profileRecords(records) {
+export function profileRecords(records, transformedFields) {
   if (records === undefined) {
     return {};
   }
@@ -47,6 +47,12 @@ export function profileRecords(records) {
   };
 
   const profile = {};
+
+  transformedFields.forEach((field) => {
+    profile[field] = {};
+    profile[field].frequencies = new Map();
+    profile[field].mostFrequentValues = [];
+  });
 
   records.forEach(function (record) {
     const recordValue = record["value"];

--- a/ui/src/helpers/profileRecords.js
+++ b/ui/src/helpers/profileRecords.js
@@ -48,6 +48,7 @@ export function profileRecords(records, transformedFields) {
 
   const profile = {};
 
+  // Initialize the profile of fields that define a transform
   transformedFields.forEach((field) => {
     profile[field] = {};
     profile[field].frequencies = new Map();


### PR DESCRIPTION
We automatically profile the schema of records by inspecting the results of the pipeline preview.

If pipeline drops fields or entire records, we previously have not been able to render fields that defined a transform or filter, making it hard to users to revert them.

With this fix, we automatically add fields, which define a transform or filter, to the profiled schema of the records, enabling users to always change any part of the pipeline, regardless of whether the preview returns records or not.

Before this fix, the grid would stay completely empty and uneditable, if all records have been filtered out:
![Screenshot 2022-12-21 at 16 19 31](https://user-images.githubusercontent.com/128683/208941345-01a64389-bb22-4162-b4cc-d8e3fd9e3fc8.png)

With this fix, we still show the field that applies the filter, allowing users to potentially remove the filter again:
![Screenshot 2022-12-21 at 16 19 45](https://user-images.githubusercontent.com/128683/208941448-5152c6f0-a84e-4802-990d-5bb3260a502d.png)
