### PR TITLE
fix(pipeline): Configure SerDe

### DIFF
--- a/pipeline/src/main/java/io/datacater/KafkaConfig.java
+++ b/pipeline/src/main/java/io/datacater/KafkaConfig.java
@@ -13,7 +13,7 @@ import javax.ws.rs.Produces;
 import java.util.Map;
 
 public class KafkaConfig {
-    static private final String errorMsg= "The given Kafka Configuration could not be mapped: %s";
+    static private final String errorMsg = "The given Kafka Configuration could not be mapped: %s";
     static final String KEY_DESERIALIZER =
             ConfigProvider.getConfig()
                     .getOptionalValue("datacater.serde.key.deserializer", String.class)
@@ -30,6 +30,7 @@ public class KafkaConfig {
             ConfigProvider.getConfig()
                     .getOptionalValue("datacater.serde.value.serializer", String.class)
                     .orElse("io.datacater.core.serde.JsonSerializer");
+
     static final String DATACATER_STREAMIN_TOPIC =
             ConfigProvider.getConfig()
                     .getOptionalValue("mp.messaging.incoming.streamin.topic", String.class)
@@ -38,4 +39,24 @@ public class KafkaConfig {
             ConfigProvider.getConfig()
                     .getOptionalValue("mp.messaging.incoming.streamout.topic", String.class)
                     .orElse("streamout");
+
+    static final String DATACATER_STREAMIN_CONFIG =
+            ConfigProvider.getConfig()
+                    .getOptionalValue("datacater.streamin.config", String.class)
+                    .orElse( "{}");
+    static final String DATACATER_STREAMOUT_CONFIG =
+            ConfigProvider.getConfig()
+                    .getOptionalValue("datacater.streamout.config", String.class)
+                    .orElse( "{}");
+
+    public static Map<String, Object> mapConfig(String json){
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String, Object> map;
+        try{
+            map = mapper.readValue(json, new TypeReference<>(){});
+        } catch (JsonProcessingException e){
+            throw new KafkaConfigurationException(String.format(errorMsg, e.getMessage()));
+        }
+        return map;
+    }
 }

--- a/pipeline/src/main/java/io/datacater/Pipeline.java
+++ b/pipeline/src/main/java/io/datacater/Pipeline.java
@@ -14,6 +14,7 @@ import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.time.Duration;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import java.util.UUID;
 import java.util.concurrent.CompletionException;
@@ -23,6 +24,7 @@ import io.vertx.mutiny.core.buffer.Buffer;
 import io.vertx.mutiny.ext.web.client.HttpRequest;
 import io.vertx.mutiny.ext.web.client.HttpResponse;
 import io.vertx.mutiny.ext.web.client.WebClient;
+import io.quarkus.runtime.StartupEvent;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -56,6 +58,13 @@ public class Pipeline {
   @Channel(PipelineConfig.STREAMOUT)
   @OnOverflow(value = OnOverflow.Strategy.UNBOUNDED_BUFFER)
   Emitter<Record<byte[], byte[]>> producer;
+
+  void onStart(@Observes StartupEvent ev) {
+    keyDeserializer.configure(KafkaConfig.mapConfig(KafkaConfig.DATACATER_STREAMIN_CONFIG), true);
+    valueDeserializer.configure(KafkaConfig.mapConfig(KafkaConfig.DATACATER_STREAMIN_CONFIG), false);
+    keySerializer.configure(KafkaConfig.mapConfig(KafkaConfig.DATACATER_STREAMOUT_CONFIG), true);
+    valueSerializer.configure(KafkaConfig.mapConfig(KafkaConfig.DATACATER_STREAMOUT_CONFIG), false);
+  }
 
   @Incoming(PipelineConfig.STREAMIN)
   @Blocking

--- a/platform-api/src/main/java/io/datacater/core/deployment/K8Deployment.java
+++ b/platform-api/src/main/java/io/datacater/core/deployment/K8Deployment.java
@@ -1,5 +1,6 @@
 package io.datacater.core.deployment;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -373,6 +374,22 @@ public class K8Deployment {
               StaticConfig.STREAMOUT_ENV_PREFIX,
               configOptionAsEnvVariable,
               streamOutConfig.get(configOption).toString()));
+    }
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    try {
+      environmentVariables.add(
+          createEnvVariable(
+              StaticConfig.DATACATER_STREAMIN_CONFIG,
+              "",
+              objectMapper.writeValueAsString(streamInConfig)));
+      environmentVariables.add(
+          createEnvVariable(
+              StaticConfig.DATACATER_STREAMOUT_CONFIG,
+              "",
+              objectMapper.writeValueAsString(streamOutConfig)));
+    } catch (JsonProcessingException e) {
+      throw new CreateDeploymentException(StringUtilities.wrapString(e.getMessage()));
     }
 
     // Set topic name of stream in and stream out

--- a/platform-api/src/main/java/io/datacater/core/deployment/StaticConfig.java
+++ b/platform-api/src/main/java/io/datacater/core/deployment/StaticConfig.java
@@ -10,6 +10,8 @@ public class StaticConfig {
   static final String STREAMIN_ENV_PREFIX = "MP_MESSAGING_INCOMING_STREAMIN_";
   static final String STREAMOUT_ENV_PREFIX = "MP_MESSAGING_OUTGOING_STREAMOUT_";
   static final String DATACATER_SERDE_ENV_PREFIX = "DATACATER_SERDE_";
+  static final String DATACATER_STREAMIN_CONFIG = "DATACATER_STREAMIN_CONFIG";
+  static final String DATACATER_STREAMOUT_CONFIG = "DATACATER_STREAMOUT_CONFIG";
   static final String DATACATER_PIPELINE = "datacater-pipeline";
   static final String PYTHON_RUNNER_NAME = "python-runner";
   static final String APP = "datacater.io/app";


### PR DESCRIPTION
Pass the consumer/producer config to the SerDe classes, such that they are correctly configured.

This is needed for SerDe implementations with a configuration, e.g., AVRO.