### PR TITLE
fix(streams/inspect): Overwrite `max.poll.records`

### DIFF
--- a/platform-api/src/main/java/io/datacater/core/stream/StreamsUtilities.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/StreamsUtilities.java
@@ -16,10 +16,10 @@ public class StreamsUtilities {
   @Inject DataCaterSessionFactory dsf;
 
   public Uni<List<StreamMessage>> getStreamMessages(UUID uuid) {
-    return getStreamMessages(uuid, 100);
+    return getStreamMessages(uuid, 100L);
   }
 
-  public Uni<List<StreamMessage>> getStreamMessages(UUID uuid, long limit) {
+  public Uni<List<StreamMessage>> getStreamMessages(UUID uuid, Long limit) {
     return dsf.withTransaction(
         ((session, transaction) ->
             session
@@ -31,6 +31,9 @@ public class StreamsUtilities {
                         e -> {
                           try {
                             Stream stream = Stream.from(e);
+                            // Overwrite Kafka Consumer property `max.poll.records` with the
+                            // parameter `limit`
+                            stream.spec().getKafka().put("max.poll.records", limit.intValue());
                             StreamService kafkaAdmin = KafkaStreamsAdmin.from(stream);
                             List<StreamMessage> messages = kafkaAdmin.inspect(stream, limit);
                             kafkaAdmin.close();


### PR DESCRIPTION
The `/streams/:uuid/inspect` endpoint allows to provide the parameter `limit`, which defines the number of to-be-retrieved records.

Internally, the endpoint is using Kafka's Consumer API for retrieving the records. Thus, the number of retrieved records is additionally limited by the consumer property `max.poll.records`.

Unless the stream spec overwrites this property, `max.poll.records` defaults to `500`.

To enable users to provide any value for the `limit` parameter, we now overwrite `max.poll.records` when retrieving records and set it to `value`.