### PR TITLE
fix(ui): Make log parsing more robust

### DIFF
--- a/ui/src/containers/deployments/DeploymentLogs.js
+++ b/ui/src/containers/deployments/DeploymentLogs.js
@@ -162,13 +162,28 @@ class DeploymentLogs extends Component {
                       >
                         {this.state.logMessages.map((logMessage, idx) => (
                           <React.Fragment key={idx}>
-                            <span className="me-2" style={{ color: "#ae75e6" }}>
-                              {logMessage.timestamp}
-                            </span>
-                            <span className="me-2" style={{ color: "#b4d2ea" }}>
-                              {logMessage.loggerName}
-                            </span>
-                            {logMessage.message} <br />
+                            {typeof logMessage === "string" && (
+                              <>
+                                {logMessage} <br />
+                              </>
+                            )}
+                            {typeof logMessage !== "string" && (
+                              <>
+                                <span
+                                  className="me-2"
+                                  style={{ color: "#ae75e6" }}
+                                >
+                                  {logMessage.timestamp}
+                                </span>
+                                <span
+                                  className="me-2"
+                                  style={{ color: "#b4d2ea" }}
+                                >
+                                  {logMessage.loggerName}
+                                </span>
+                                {logMessage.message} <br />
+                              </>
+                            )}
                           </React.Fragment>
                         ))}
                       </code>

--- a/ui/src/reducers/deployments.js
+++ b/ui/src/reducers/deployments.js
@@ -101,7 +101,11 @@ const deployments = (state, action) => {
         .split("\n")
         .slice(-101, -1)
         .map((logLine) => {
-          return JSON.parse(logLine);
+          try {
+            return JSON.parse(logLine);
+          } catch (e) {
+            return logLine;
+          }
         });
       return {
         ...state,


### PR DESCRIPTION
By default, the `/deployments/$uuid/logs` endpoint returns a deployment's logs in the JSON-LD format.

In rare cases, some lines are simple strings not JSON objects. This commit allows us to deal with such edge cases without throwing an error in the frontend.