### PR TITLE
fix(ui/pipeline): Load streams before pipeline

### DIFF
--- a/ui/src/containers/pipelines/PipelineSettings.js
+++ b/ui/src/containers/pipelines/PipelineSettings.js
@@ -25,9 +25,14 @@ class PipelineSettings extends Component {
 
   componentDidMount() {
     this.props
-      .fetchPipeline(this.getPipelineId())
-      .then(() => this.setState({ pipeline: this.props.pipelines.pipeline }));
-    this.props.fetchStreams();
+      .fetchStreams()
+      .then(() =>
+        this.props
+          .fetchPipeline(this.getPipelineId())
+          .then(() =>
+            this.setState({ pipeline: this.props.pipelines.pipeline })
+          )
+      );
   }
 
   getPipelineId() {


### PR DESCRIPTION
In some cases, the Settings page of a pipeline in the UI does not show the streams of the pipeline as selected. This happens when the pipeline object has been loaded before the stream objects.

This commit fixes this issue by enforcing that streams are retrieved from the backend before the pipeline.

It looks as follows when this bug occurs:
<img width="1624" alt="Screenshot 2022-12-22 at 14 03 04" src="https://user-images.githubusercontent.com/128683/209140261-5d29f9d0-bc58-4fe2-bfbf-a68f84aaa0a2.png">

It should however look as follows:
<img width="1624" alt="Screenshot 2022-12-22 at 14 03 39" src="https://user-images.githubusercontent.com/128683/209140288-7cad2c70-5aac-49a5-9954-2868ae645c22.png">
