### PR TITLE
feat(api-path): remove root-path from non-app routes

### DIFF
--- a/platform-api/src/main/resources/application.yml
+++ b/platform-api/src/main/resources/application.yml
@@ -26,6 +26,7 @@ quarkus  :
           admin: admin,dev,user
   http:
     root-path: /api/${datacater.api.version}
+    non-application-root-path: /q
     cors: true
     auth:
       basic: true


### PR DESCRIPTION
This PR is to remove our versioned path prefix from non-application resources that are not managed by us (`/health`, `/metrics`, etc.)