### PR TITLE
When previewing a pipeline in the UI, visualize changed records

### DIFF
--- a/python-runner/test_runner.py
+++ b/python-runner/test_runner.py
@@ -1,43 +1,10 @@
 # Run tests: $ python3 -m pytest
 
 from fastapi.testclient import TestClient
-import json
-import os
 
 from runner import app
 
 client = TestClient(app)
-
-
-def test_batch_file_apply_transform():
-    # Upload pipeline
-    client.post(
-        "/pipeline",
-        json={
-            "spec": {
-                "steps": [
-                    {
-                        "kind": "Field",
-                        "fields": {"company": {"transform": {"key": "trim"}}},
-                    }
-                ]
-            }
-        },
-    )
-    # Apply pipeline to records
-    raw_records = [
-        {"key": {}, "value": {"company": " DataCater GmbH     "}, "metadata": {}}
-    ]
-    with open("records.json", "w") as outfile:
-        json.dump(raw_records, outfile)
-    response = client.post("/batch-file", json={"fileIn": "records.json"})
-    assert response.status_code == 200
-    with open(response.json()["fileOut"]) as infile:
-        assert json.load(infile) == [
-            {"key": {}, "value": {"company": "DataCater GmbH"}, "metadata": {}}
-        ]
-    os.remove("records.json")
-    os.remove("records.json.out")
 
 
 def test_batch_apply_transform():
@@ -268,7 +235,11 @@ def test_preview_apply_transform():
     )
 
     assert response.json() == [
-        {"key": {}, "value": {"company": "DataCater GmbH"}, "metadata": {}}
+        {
+            "key": {},
+            "value": {"company": "DataCater GmbH"},
+            "metadata": {"lastChange": {"key": {}, "value": {"company": 0}}},
+        }
     ]
 
     assert response.status_code == 200
@@ -304,7 +275,11 @@ def test_preview_apply_user_defined_transform():
     )
 
     assert response.json() == [
-        {"key": {}, "value": {"company": "DataCater AG"}, "metadata": {}}
+        {
+            "key": {},
+            "value": {"company": "DataCater AG"},
+            "metadata": {"lastChange": {"key": {}, "value": {"company": 0}}},
+        }
     ]
 
     assert response.status_code == 200
@@ -352,7 +327,9 @@ def test_preview_apply_user_defined_record_transform():
         {
             "key": {},
             "value": {"company": "DataCater AG", "website": "https://datacater.io"},
-            "metadata": {},
+            "metadata": {
+                "lastChange": {"key": {}, "value": {"company": 1, "website": 0}}
+            },
         }
     ]
 
@@ -388,7 +365,11 @@ def test_preview_apply_filter():
     )
 
     assert response.json() == [
-        {"key": {}, "value": {"company": "DataCater GmbH"}, "metadata": {}}
+        {
+            "key": {},
+            "value": {"company": "DataCater GmbH"},
+            "metadata": {"lastChange": {"key": {}, "value": {}}},
+        }
     ]
 
     assert response.status_code == 200
@@ -425,7 +406,11 @@ def test_preview_apply_user_defined_filter():
     )
 
     assert response.json() == [
-        {"key": {}, "value": {"company": "DataKater GmbH"}, "metadata": {}}
+        {
+            "key": {},
+            "value": {"company": "DataKater GmbH"},
+            "metadata": {"lastChange": {"key": {}, "value": {}}},
+        }
     ]
 
     assert response.status_code == 200
@@ -470,7 +455,11 @@ def test_preview_apply_user_defined_record_filter():
     )
 
     assert response.json() == [
-        {"key": {}, "value": {"company": "DataCater AG"}, "metadata": {}}
+        {
+            "key": {},
+            "value": {"company": "DataCater AG"},
+            "metadata": {"lastChange": {"key": {}, "value": {"company": 0}}},
+        }
     ]
 
     assert response.status_code == 200
@@ -513,8 +502,16 @@ def test_preview_filter_transform_combination():
     )
 
     assert response.json() == [
-        {"key": {}, "value": {"company": "DataCater AG"}, "metadata": {}},
-        {"key": {}, "value": {"company": "DataKater GmbH"}, "metadata": {}},
+        {
+            "key": {},
+            "value": {"company": "DataCater AG"},
+            "metadata": {"lastChange": {"key": {}, "value": {"company": 0}}},
+        },
+        {
+            "key": {},
+            "value": {"company": "DataKater GmbH"},
+            "metadata": {"lastChange": {"key": {}, "value": {}}},
+        },
     ]
 
     assert response.status_code == 200

--- a/ui/src/components/pipelines/pipeline_designer/Grid.js
+++ b/ui/src/components/pipelines/pipeline_designer/Grid.js
@@ -22,11 +22,12 @@ class Grid extends Component {
     let classNames = "sample-cell w-100 text-nowrap";
 
     const field = column.field;
-    const rawValue = sample["value"][field.name];
-    const error = sample["metadata"]["error"];
+    const fieldName = field.name;
+    const rawValue = sample["value"][fieldName];
 
     // Check whether an error has occured when applying the pipeline spec
     // in the current or a previous step
+    const error = sample["metadata"]["error"];
     if (error !== undefined) {
       const myRegexp = /steps\[(\d+)\].*/g;
       const match = myRegexp.exec(error["location"]["path"]);
@@ -42,7 +43,7 @@ class Grid extends Component {
         return (
           <div
             className={classNames}
-            key={field.name}
+            key={fieldName}
             onClick={() => {
               column.openDebugViewFunc(sample);
             }}
@@ -53,18 +54,19 @@ class Grid extends Component {
       }
     }
 
-    /*
+    // Check whether the field has been changed in the current or a previous step
+    const lastChange = sample["metadata"]["lastChange"];
     if (
-      sample.lastChange !== undefined &&
-      sample.lastChange[field] !== undefined
+      lastChange !== undefined &&
+      lastChange["value"] !== undefined &&
+      lastChange["value"][fieldName] !== undefined
     ) {
-      if (sample.lastChange[field] === this.props.currentStep) {
+      if (lastChange["value"][fieldName] + 1 === column.currentStep) {
         classNames += " changed-in-current-step";
-      } else {
+      } else if (lastChange["value"][fieldName] + 1 < column.currentStep) {
         classNames += " changed-in-previous-step";
       }
     }
-    */
 
     if (
       this.props.editColumnField !== undefined &&
@@ -74,7 +76,7 @@ class Grid extends Component {
     }
 
     return (
-      <div className={classNames} key={field.name} title={"" + rawValue}>
+      <div className={classNames} key={fieldName} title={"" + rawValue}>
         {renderTableCellContent(rawValue)}
       </div>
     );


### PR DESCRIPTION
Let the `/preview` endpoint return which records have been changed by a pipeline:

* Each record's `metadata` now feature a new field `lastChange`
* The metadata field `lastChange` holds two keys, `key` and `value`
* If the record key holds JSON data, the object `record.metadata.lastChange.key` features an entry for each changed field of the JSON object, indicating the last step that has changed the field
* If the record value holds JSON data, the object `record.metadata.lastChange.value` features an entry for each changed field of the JSON object, indicating the last step that has changed the field

Example record:

```json
{
        "key": null,
        "value": {
                "name": "DataCater GmbH",
                "website": "https://datacater.io"
        }
}
```

If the previewed pipeline modifies the value's field `name` in the third step, the response of the `/preview` endpoint looks as follows:

```json
{
        ...,
        "metadata": {
                ....,
                "lastChange": {
                        "key": {},
                        "value": {
                                "name": 2
                        }
                }
        }
}
```

The UI can use these information to visually highlight cells/fields that have been modified by the previewed pipeline:

![Screenshot 2023-01-09 at 13 27 41](https://user-images.githubusercontent.com/128683/211308159-ea215429-3f90-496f-a1be-812617a6fe30.png)

Fixes #42 