### PR TITLE
feat(pipeline-designer): Do not show type warnings if type is unknown

### DIFF
--- a/ui/src/components/pipelines/pipeline_designer/context_bar/FilterConfig.js
+++ b/ui/src/components/pipelines/pipeline_designer/context_bar/FilterConfig.js
@@ -64,6 +64,7 @@ class FilterConfig extends Component {
 
       // Does the field-level filter support the detected data type?
       if (
+        fieldDataType !== undefined &&
         filter !== undefined &&
         filter.labels !== undefined &&
         filter.labels["input-types"] !== undefined

--- a/ui/src/components/pipelines/pipeline_designer/context_bar/TransformConfig.js
+++ b/ui/src/components/pipelines/pipeline_designer/context_bar/TransformConfig.js
@@ -66,6 +66,7 @@ class TransformConfig extends Component {
 
       // Does the field-level transform support the detected data type?
       if (
+        fieldDataType !== undefined &&
         transform !== undefined &&
         transform.labels !== undefined &&
         transform.labels["input-types"] !== undefined


### PR DESCRIPTION
In the UI, we warn the user if the inferred data type does not match the data type expected by a filter or transform.

If we cannot infer the data type from the sample data, we should not show a warning and confuse the user.