### PR TITLE
chore(ui): Remove the max line width from the YAML formatter

### DIFF
--- a/ui/src/components/pipelines/pipeline_designer/context_bar/DebugView.js
+++ b/ui/src/components/pipelines/pipeline_designer/context_bar/DebugView.js
@@ -1,8 +1,8 @@
 import React, { Component } from "react";
 import { LifeBuoy } from "react-feather";
-import yaml from "js-yaml";
 import { Button } from "react-bootstrap";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { jsonToYaml } from "../../../../helpers/jsonToYaml";
 
 class DebugView extends Component {
   constructor(props) {
@@ -47,7 +47,7 @@ class DebugView extends Component {
       if (match != null && match.length == 3) {
         const step = parseInt(match[1]);
         const fieldName = match[2];
-        debugContent = yaml.dump(pipeline.spec.steps[step].fields[fieldName]);
+        debugContent = jsonToYaml(pipeline.spec.steps[step].fields[fieldName]);
       } else {
         // If we fail reading the step index and the field name from the
         // location path, we should try only getting the step index.
@@ -59,7 +59,7 @@ class DebugView extends Component {
         const match = /steps\[(\d+)\].*/g.exec(error["location"]["path"]);
         if (match != null && match.length == 2) {
           const step = parseInt(match[1]);
-          debugContent = yaml.dump(pipeline.spec.steps[step]);
+          debugContent = jsonToYaml(pipeline.spec.steps[step]);
         }
       }
     }

--- a/ui/src/components/pipelines/pipeline_designer/context_bar/FilterConfig.js
+++ b/ui/src/components/pipelines/pipeline_designer/context_bar/FilterConfig.js
@@ -1,9 +1,9 @@
 import React, { Component } from "react";
 import { Button, OverlayTrigger, Tooltip } from "react-bootstrap";
 import { Filter as FilterIcon, HelpCircle } from "react-feather";
-import yaml from "js-yaml";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import CodeEditor from "./CodeEditor";
+import { jsonToYaml } from "../../../../helpers/jsonToYaml";
 
 class FilterConfig extends Component {
   constructor(props) {
@@ -275,7 +275,7 @@ class FilterConfig extends Component {
                   background: "#f7fbf8",
                 }}
               >
-                {yaml.dump(filter)}
+                {jsonToYaml(filter)}
               </SyntaxHighlighter>
             </div>
           )}

--- a/ui/src/components/pipelines/pipeline_designer/context_bar/TransformConfig.js
+++ b/ui/src/components/pipelines/pipeline_designer/context_bar/TransformConfig.js
@@ -1,10 +1,10 @@
 import React, { Component } from "react";
 import { Button, OverlayTrigger, Tooltip } from "react-bootstrap";
 import { HelpCircle, Package } from "react-feather";
-import yaml from "js-yaml";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import NewFieldForm from "./NewFieldForm";
 import CodeEditor from "./CodeEditor";
+import { jsonToYaml } from "../../../../helpers/jsonToYaml";
 
 class TransformConfig extends Component {
   constructor(props) {
@@ -291,7 +291,7 @@ class TransformConfig extends Component {
                   background: "#f7fbf8",
                 }}
               >
-                {yaml.dump(transform)}
+                {jsonToYaml(transform)}
               </SyntaxHighlighter>
             </div>
           )}

--- a/ui/src/containers/deployments/ShowDeployment.js
+++ b/ui/src/containers/deployments/ShowDeployment.js
@@ -2,7 +2,6 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { Trash2 } from "react-feather";
 import { Redirect } from "react-router-dom";
-import yaml from "js-yaml";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import parsePrometheusTextFormat from "parse-prometheus-text-format";
 import Breadcrumb from "../../components/layout/Breadcrumb";
@@ -16,6 +15,7 @@ import {
   resetDeploymentHealth,
   resetDeploymentMetrics,
 } from "../../actions/deployments";
+import { jsonToYaml } from "../../helpers/jsonToYaml";
 
 class ShowDeployment extends Component {
   constructor(props) {
@@ -317,7 +317,7 @@ class ShowDeployment extends Component {
                   showInlineLineNumbers={true}
                   customStyle={{ marginBottom: "0px", background: "none" }}
                 >
-                  {yaml.dump(deployment)}
+                  {jsonToYaml(deployment)}
                 </SyntaxHighlighter>
               </div>
             </div>

--- a/ui/src/containers/pipelines/ShowPipeline.js
+++ b/ui/src/containers/pipelines/ShowPipeline.js
@@ -7,6 +7,7 @@ import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import Breadcrumb from "../../components/layout/Breadcrumb";
 import Header from "../../components/layout/Header";
 import { deletePipeline, fetchPipeline } from "../../actions/pipelines";
+import { jsonToYaml } from "../../helpers/jsonToYaml";
 
 class ShowPipeline extends Component {
   constructor(props) {
@@ -107,7 +108,7 @@ class ShowPipeline extends Component {
                   showInlineLineNumbers={true}
                   customStyle={{ marginBottom: "0px", background: "none" }}
                 >
-                  {yaml.dump(pipeline)}
+                  {jsonToYaml(pipeline)}
                 </SyntaxHighlighter>
               </div>
             </div>

--- a/ui/src/containers/streams/ShowStream.js
+++ b/ui/src/containers/streams/ShowStream.js
@@ -2,11 +2,11 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { Trash2 } from "react-feather";
 import { Redirect } from "react-router-dom";
-import yaml from "js-yaml";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import Breadcrumb from "../../components/layout/Breadcrumb";
 import Header from "../../components/layout/Header";
 import { deleteStream, fetchStream } from "../../actions/streams";
+import { jsonToYaml } from "../../helpers/jsonToYaml";
 
 class ShowStream extends Component {
   constructor(props) {
@@ -107,7 +107,7 @@ class ShowStream extends Component {
                   showInlineLineNumbers={true}
                   customStyle={{ marginBottom: "0px", background: "none" }}
                 >
-                  {yaml.dump(stream)}
+                  {jsonToYaml(stream)}
                 </SyntaxHighlighter>
               </div>
             </div>

--- a/ui/src/helpers/jsonToYaml.js
+++ b/ui/src/helpers/jsonToYaml.js
@@ -1,0 +1,5 @@
+const yaml = require("js-yaml");
+
+export function jsonToYaml(json) {
+  return yaml.dump(json, { lineWidth: -1 });
+}


### PR DESCRIPTION
By default, `js-yaml` breaks lines after 80 characters.

I removed the limitation, so we do not break lines after a specific length, which could become problematic when, for instance, breaking inlined Python functions that contain comments into multiple lines.

Example:
![Screenshot 2023-01-12 at 15 15 30](https://user-images.githubusercontent.com/128683/212089834-e785be70-d7f8-4ffa-b7d8-7fc2480dc0ed.png)


I moved the YAML formatting to a central helper function so we do not have to maintain configuration at multiple locations.