### PR TITLE
Improve robustness of pre-defined filters and transforms

### DIFF
--- a/filters/contain/filter.py
+++ b/filters/contain/filter.py
@@ -1,2 +1,2 @@
 def filter(value, row: dict, config: dict) -> bool:
-    return config["value"] in value
+    return config.get("value") is None or config["value"] in value

--- a/filters/contain/test_filter.py
+++ b/filters/contain/test_filter.py
@@ -21,10 +21,23 @@ def test_string_does_not_contain_substring():
     )
 
 
+def test_null_config():
+    assert (
+        filter.filter(
+            "DataCater is the developer-friendly ETL platform for transforming data in motion.",
+            {},
+            {"value": None},
+        )
+        is True
+    )
+
+
 def test_no_config():
-    with pytest.raises(KeyError):
+    assert (
         filter.filter(
             "DataCater is the developer-friendly ETL platform for transforming data in motion.",
             {},
             {},
         )
+        is True
+    )

--- a/filters/endwith/filter.py
+++ b/filters/endwith/filter.py
@@ -1,2 +1,2 @@
 def filter(value, row: dict, config: dict) -> bool:
-    return value.endswith(config["value"])
+    return config.get("value") is None or value.endswith(config["value"])

--- a/filters/endwith/test_filter.py
+++ b/filters/endwith/test_filter.py
@@ -21,10 +21,23 @@ def test_string_does_not_end_with_substring():
     )
 
 
+def test_null_config():
+    assert (
+        filter.filter(
+            "DataCater is the developer-friendly ETL platform for transforming data in motion.",
+            {},
+            {"value": None},
+        )
+        == True
+    )
+
+
 def test_no_config():
-    with pytest.raises(KeyError):
+    assert (
         filter.filter(
             "DataCater is the developer-friendly ETL platform for transforming data in motion.",
             {},
             {},
         )
+        == True
+    )

--- a/filters/equal/filter.py
+++ b/filters/equal/filter.py
@@ -1,2 +1,21 @@
 def filter(value, row: dict, config: dict) -> bool:
-    return value == config.get("value", None)
+    if config.get("value") is None:
+        return True
+    elif isinstance(value, bool):
+        bool_value = config.get("value") in [
+            "true",
+            "True",
+            "TRUE",
+            "t",
+            "y",
+            "yes",
+            "1",
+            1,
+        ]
+        return value == bool_value
+    elif isinstance(value, int):
+        return value == int(config.get("value"))
+    elif isinstance(value, float):
+        return value == float(config.get("value"))
+    else:
+        return value == config.get("value")

--- a/filters/equal/test_filter.py
+++ b/filters/equal/test_filter.py
@@ -29,12 +29,12 @@ def test_string_does_not_equal_number():
     assert filter.filter("42", {}, {"value": 42}) is False
 
 
-def test_number_does_not_equal_string():
-    assert filter.filter(42, {}, {"value": "42"}) is False
+def test_number_does_equal_string():
+    assert filter.filter(42, {}, {"value": "42"}) is True
 
 
 def test_boolean_does_not_equal_string():
-    assert filter.filter(True, {}, {"value": "True"}) is False
+    assert filter.filter(True, {}, {"value": "True"}) is True
 
 
 def test_float_equals_int():
@@ -46,9 +46,12 @@ def test_int_equals_float():
 
 
 def test_empty_string_does_not_equal_none():
-    assert filter.filter("", {}, {"value": None}) is False
+    assert filter.filter("", {}, {"value": None}) is True
+
+
+def null_config():
+    assert filter.filter(42, {}, {"value": None}) is False
 
 
 def no_config():
-    with pytest.raises(KeyError):
-        filter.filter(42, {}, {})
+    assert filter.filter(42, {}, {}) is True

--- a/filters/greaterthan/filter.py
+++ b/filters/greaterthan/filter.py
@@ -1,2 +1,9 @@
 def filter(value, row: dict, config: dict) -> bool:
-    return value > config["value"]
+    if config.get("value", None) is None:
+        return True
+    elif isinstance(value, int):
+        return value > int(config["value"])
+    elif isinstance(value, float):
+        return value > float(config["value"])
+    else:
+        return value > config["value"]

--- a/filters/greaterthan/test_filter.py
+++ b/filters/greaterthan/test_filter.py
@@ -19,10 +19,17 @@ def test_int_is_greater_than_float():
     assert filter.filter(5, {}, {"value": 4.0})
 
 
+def test_int_is_greater_than_int_string():
+    assert filter.filter(5, {}, {"value": "4"})
+
+
 def test_float_is_greater_than_int():
     assert filter.filter(5.0, {}, {"value": 4})
 
 
+def null_config():
+    assert filter.filter(42, {}, {"value": None}) is False
+
+
 def no_config():
-    with pytest.raises(KeyError):
-        filter.filter(42, {}, {})
+    assert filter.filter(42, {}, {}) is False

--- a/filters/lessthan/filter.py
+++ b/filters/lessthan/filter.py
@@ -1,2 +1,9 @@
 def filter(value, row: dict, config: dict) -> bool:
-    return value < config["value"]
+    if config.get("value", None) is None:
+        return True
+    elif isinstance(value, int):
+        return value < int(config["value"])
+    elif isinstance(value, float):
+        return value < float(config["value"])
+    else:
+        return value < config["value"]

--- a/filters/lessthan/test_filter.py
+++ b/filters/lessthan/test_filter.py
@@ -1,28 +1,35 @@
-import greaterthan.filter as filter
+import lessthan.filter as filter
 import pytest
 
 
-def test_string_is_greater_than_other_string():
-    assert filter.filter("Python", {}, {"value": "Php"})
+def test_string_is_less_than_other_string():
+    assert filter.filter("Python", {}, {"value": "Ruby"})
 
 
-def test_string_is_greater_than_number_raises_exception():
+def test_string_is_less_than_number_raises_exception():
     with pytest.raises(TypeError):
-        filter.filter("5", {}, {"value": 4})
+        filter.filter("5", {}, {"value": 6})
 
 
-def test_number_is_greater_than_other_number():
-    assert filter.filter(5, {}, {"value": 4})
+def test_number_is_less_than_other_number():
+    assert filter.filter(5, {}, {"value": 6})
 
 
-def test_int_is_greater_than_float():
-    assert filter.filter(5, {}, {"value": 4.0})
+def test_int_is_less_than_float():
+    assert filter.filter(5, {}, {"value": 6.0})
 
 
-def test_float_is_greater_than_int():
-    assert filter.filter(5.0, {}, {"value": 4})
+def test_float_is_less_than_int():
+    assert filter.filter(5.0, {}, {"value": 6})
+
+
+def test_int_is_less_than_int_string():
+    assert filter.filter(5, {}, {"value": "6"})
+
+
+def null_config():
+    assert filter.filter(42, {}, {}) is False
 
 
 def no_config():
-    with pytest.raises(KeyError):
-        filter.filter(42, {}, {})
+    assert filter.filter(42, {}, {}) is False

--- a/filters/notequal/filter.py
+++ b/filters/notequal/filter.py
@@ -1,2 +1,19 @@
 def filter(value, row: dict, config: dict) -> bool:
-    return value != config["value"]
+    if isinstance(value, bool):
+        bool_value = config.get("value") in [
+            "true",
+            "True",
+            "TRUE",
+            "t",
+            "y",
+            "yes",
+            "1",
+            1,
+        ]
+        return value != bool_value
+    elif isinstance(value, int):
+        return value != int(config.get("value"))
+    elif isinstance(value, float):
+        return value != float(config.get("value"))
+    else:
+        return value != config.get("value")

--- a/filters/notequal/test_filter.py
+++ b/filters/notequal/test_filter.py
@@ -32,12 +32,12 @@ def test_string_does_not_equal_number():
     assert filter.filter("42", {}, {"value": 42}) is True
 
 
-def test_number_does_not_equal_string():
-    assert filter.filter(42, {}, {"value": "42"}) is True
+def test_number_does_not_equal_number_string():
+    assert filter.filter(42, {}, {"value": "42"}) is False
 
 
-def test_boolean_does_not_equal_string():
-    assert filter.filter(True, {}, {"value": "True"}) is True
+def test_boolean_does_not_equal_string_bool():
+    assert filter.filter(True, {}, {"value": "True"}) is False
 
 
 def test_float_equals_int():
@@ -53,5 +53,4 @@ def test_empty_string_does_not_equal_none():
 
 
 def no_config():
-    with pytest.raises(KeyError):
-        filter.filter(42, {}, {})
+    assert filter.filter(42, {}, {}) is False

--- a/filters/regexp/filter.py
+++ b/filters/regexp/filter.py
@@ -1,4 +1,4 @@
 def filter(value, row: dict, config: dict) -> bool:
     import re
 
-    return bool(re.match(config["value"], value))
+    return config.get("value") is None or bool(re.match(config["value"], value))

--- a/filters/regexp/test_filter.py
+++ b/filters/regexp/test_filter.py
@@ -22,3 +22,19 @@ def test_string_regexp_does_not_match():
         )
         is False
     )
+
+
+def test_string_regexp_null_config():
+    assert filter.filter(
+        "DataCater is the developer-friendly ETL platform for transforming data in motion.",
+        {},
+        {"value": None},
+    )
+
+
+def test_string_regexp_no_config():
+    assert filter.filter(
+        "DataCater is the developer-friendly ETL platform for transforming data in motion.",
+        {},
+        {},
+    )

--- a/filters/startwith/filter.py
+++ b/filters/startwith/filter.py
@@ -1,2 +1,2 @@
 def filter(value, row: dict, config: dict) -> bool:
-    return value.startswith(config["value"])
+    return config.get("value") is None or value.startswith(config["value"])

--- a/filters/startwith/test_filter.py
+++ b/filters/startwith/test_filter.py
@@ -21,10 +21,17 @@ def test_string_does_not_start_with_substring():
     )
 
 
+def test_null_config():
+    assert filter.filter(
+        "DataCater is the developer-friendly ETL platform for transforming data in motion.",
+        {},
+        {"value": None},
+    )
+
+
 def test_no_config():
-    with pytest.raises(KeyError):
-        filter.filter(
-            "DataCater is the developer-friendly ETL platform for transforming data in motion.",
-            {},
-            {},
-        )
+    assert filter.filter(
+        "DataCater is the developer-friendly ETL platform for transforming data in motion.",
+        {},
+        {},
+    )

--- a/transforms/add/test_transform.py
+++ b/transforms/add/test_transform.py
@@ -15,10 +15,12 @@ def test_add_float_to_int():
 
 
 def test_add_string_to_int():
-    with pytest.raises(TypeError):
-        transform.transform(15, {}, {"value": "2022"})
+    assert transform.transform(15, {}, {"value": "2022"}) == 2037
+
+
+def test_null_config():
+    assert transform.transform(15, {}, {"value": None}) == 15
 
 
 def test_no_config():
-    with pytest.raises(KeyError):
-        transform.transform(15, {}, {})
+    assert transform.transform(15, {}, {}) == 15

--- a/transforms/add/transform.py
+++ b/transforms/add/transform.py
@@ -1,2 +1,7 @@
 def transform(value, row: dict, config: dict):
-    return value + config["value"]
+    if config.get("value") in [None, ""]:
+        return value
+    elif isinstance(value, float):
+        return value + float(config["value"])
+    elif isinstance(value, int):
+        return value + int(config["value"])

--- a/transforms/addfield/test_transform.py
+++ b/transforms/addfield/test_transform.py
@@ -19,6 +19,9 @@ def test_add_string_to_int():
         transform.transform(15, {"year": "2022"}, {"fieldName": "year"})
 
 
+def test_null_config():
+    assert transform.transform(15, {"year": "2022"}, {"fieldName": None}) == 15
+
+
 def test_no_config():
-    with pytest.raises(KeyError):
-        transform.transform(15, {"year": "2022"}, {})
+    assert transform.transform(15, {"year": "2022"}, {}) == 15

--- a/transforms/addfield/transform.py
+++ b/transforms/addfield/transform.py
@@ -1,2 +1,4 @@
 def transform(value, row: dict, config: dict):
+    if config.get("fieldName") in [None, ""]:
+        return value
     return value + row[config["fieldName"]]

--- a/transforms/appendfield/test_transform.py
+++ b/transforms/appendfield/test_transform.py
@@ -40,8 +40,21 @@ def test_append_empty_field():
         )
 
 
+def test_null_config():
+    assert (
+        transform.transform(
+            "Data streaming with ",
+            {"programmingLanguage": "Python"},
+            {"fieldName": None},
+        )
+        == "Data streaming with "
+    )
+
+
 def test_no_config():
-    with pytest.raises(KeyError):
+    assert (
         transform.transform(
             "Data streaming with ", {"programmingLanguage": "Python"}, {}
         )
+        == "Data streaming with "
+    )

--- a/transforms/appendfield/transform.py
+++ b/transforms/appendfield/transform.py
@@ -1,4 +1,6 @@
 def transform(value: str, row: dict, config: dict) -> str:
+    if config.get("fieldName") in [None, ""]:
+        return value
     # See performance of string concatenation in Python:
     # https://stackoverflow.com/questions/12169839/which-is-the-preferred-way-to-concatenate-a-string-in-python/12171382#12171382
     return value + row[config["fieldName"]]

--- a/transforms/appendvalue/test_transform.py
+++ b/transforms/appendvalue/test_transform.py
@@ -21,6 +21,12 @@ def test_append_empty_string():
     )
 
 
+def test_null_config():
+    assert (
+        transform.transform("Data streaming with ", {}, {"value": None})
+        == "Data streaming with "
+    )
+
+
 def test_no_config():
-    with pytest.raises(KeyError):
-        transform.transform("Data streaming with ", {}, {})
+    assert transform.transform("Data streaming with ", {}, {}) == "Data streaming with "

--- a/transforms/appendvalue/transform.py
+++ b/transforms/appendvalue/transform.py
@@ -1,4 +1,6 @@
 def transform(value: str, row: dict, config: dict) -> str:
+    if config.get("value") is None:
+        return value
     # See performance of string concatenation in Python:
     # https://stackoverflow.com/questions/12169839/which-is-the-preferred-way-to-concatenate-a-string-in-python/12171382#12171382
     return value + config["value"]

--- a/transforms/divide/test_transform.py
+++ b/transforms/divide/test_transform.py
@@ -6,6 +6,14 @@ def test_divide_int_by_int():
     assert transform.transform(15, {}, {"value": 3}) == 5
 
 
+def test_divide_int_by_int_string():
+    assert transform.transform(15, {}, {"value": "3"}) == 5
+
+
+def test_divide_int_by_float():
+    assert transform.transform(15, {}, {"value": 3.0}) == 5
+
+
 def test_divide_int_by_float():
     assert transform.transform(15, {}, {"value": 3.0}) == 5
 
@@ -14,10 +22,17 @@ def test_divide_float_by_float():
     assert transform.transform(6.3, {}, {"value": 2.1}) == 3.0
 
 
+def test_divide_float_by_float_string():
+    assert transform.transform(6.3, {}, {"value": "2.1"}) == 3.0
+
+
 def test_divide_float_by_int():
     assert transform.transform(6.3, {}, {"value": 2}) == 3.15
 
 
+def test_null_config():
+    assert transform.transform(15, {}, {"value": None}) == 15
+
+
 def test_no_config():
-    with pytest.raises(KeyError):
-        transform.transform(15, {}, {})
+    assert transform.transform(15, {}, {}) == 15

--- a/transforms/divide/transform.py
+++ b/transforms/divide/transform.py
@@ -1,2 +1,7 @@
 def transform(value, row: dict, config: dict):
-    return value / config["value"]
+    if config.get("value") in [None, ""]:
+        return value
+    elif isinstance(value, float):
+        return value / float(config["value"])
+    elif isinstance(value, int):
+        return value / int(config["value"])

--- a/transforms/dividefield/test_transform.py
+++ b/transforms/dividefield/test_transform.py
@@ -23,6 +23,9 @@ def test_field_does_not_exist():
         transform.transform(15, {}, {"fieldName": "number"})
 
 
+def test_null_config():
+    assert transform.transform(15, {}, {"fieldName": None}) == 15
+
+
 def test_no_config():
-    with pytest.raises(KeyError):
-        transform.transform(15, {}, {})
+    assert transform.transform(15, {}, {}) == 15

--- a/transforms/dividefield/transform.py
+++ b/transforms/dividefield/transform.py
@@ -1,2 +1,4 @@
 def transform(value, row: dict, config: dict):
+    if config.get("fieldName") in [None, ""]:
+        return value
     return value / row[config["fieldName"]]

--- a/transforms/modulo/test_transform.py
+++ b/transforms/modulo/test_transform.py
@@ -6,6 +6,10 @@ def test_modulo_int_by_int():
     assert transform.transform(14, {}, {"value": 3}) == 2
 
 
+def test_modulo_int_by_int_string():
+    assert transform.transform(14, {}, {"value": "3"}) == 2
+
+
 def test_modulo_int_by_float():
     assert transform.transform(14, {}, {"value": 3.0}) == 2
 
@@ -14,10 +18,17 @@ def test_modulo_float_by_float():
     assert round(transform.transform(6.3, {}, {"value": 2}), 1) == 0.3
 
 
+def test_modulo_float_by_float_string():
+    assert round(transform.transform(6.3, {}, {"value": "2"}), 1) == 0.3
+
+
 def test_modulo_float_by_int():
     assert round(transform.transform(6.3, {}, {"value": 2}), 1) == 0.3
 
 
+def test_null_config():
+    assert transform.transform(15, {}, {"value": None}) == 15
+
+
 def test_no_config():
-    with pytest.raises(KeyError):
-        transform.transform(15, {}, {})
+    assert transform.transform(15, {}, {}) == 15

--- a/transforms/modulo/transform.py
+++ b/transforms/modulo/transform.py
@@ -1,2 +1,7 @@
 def transform(value, row: dict, config: dict):
-    return value % config["value"]
+    if config.get("value") in [None, ""]:
+        return value
+    elif isinstance(value, float):
+        return value % float(config["value"])
+    elif isinstance(value, int):
+        return value % int(config["value"])

--- a/transforms/modulofield/test_transform.py
+++ b/transforms/modulofield/test_transform.py
@@ -29,6 +29,9 @@ def test_no_field():
         transform.transform(15, {}, {"fieldName": "number"})
 
 
+def test_null_config():
+    assert transform.transform(15, {}, {"fieldName": None}) == 15
+
+
 def test_no_config():
-    with pytest.raises(KeyError):
-        transform.transform(15, {}, {})
+    assert transform.transform(15, {}, {}) == 15

--- a/transforms/modulofield/transform.py
+++ b/transforms/modulofield/transform.py
@@ -1,2 +1,4 @@
 def transform(value, row: dict, config: dict):
+    if config.get("fieldName") in [None, ""]:
+        return value
     return value % row[config["fieldName"]]

--- a/transforms/multiply/test_transform.py
+++ b/transforms/multiply/test_transform.py
@@ -6,6 +6,10 @@ def test_multiply_int_by_int():
     assert transform.transform(5, {}, {"value": 3}) == 15
 
 
+def test_multiply_int_by_int_string():
+    assert transform.transform(5, {}, {"value": "3"}) == 15
+
+
 def test_multiply_int_by_float():
     assert transform.transform(5, {}, {"value": 3.0}) == 15
 
@@ -14,10 +18,17 @@ def test_multiply_float_by_float():
     assert round(transform.transform(2.0, {}, {"value": 3.2}), 1) == 6.4
 
 
+def test_multiply_float_by_float_string():
+    assert round(transform.transform(2.0, {}, {"value": "3.2"}), 1) == 6.4
+
+
 def test_multiply_float_by_int():
     assert round(transform.transform(2.1, {}, {"value": 3}), 1) == 6.3
 
 
+def test_null_config():
+    assert transform.transform(15, {}, {"value": None}) == 15
+
+
 def test_no_config():
-    with pytest.raises(KeyError):
-        transform.transform(15, {}, {})
+    assert transform.transform(15, {}, {}) == 15

--- a/transforms/multiply/transform.py
+++ b/transforms/multiply/transform.py
@@ -1,2 +1,7 @@
 def transform(value, row: dict, config: dict):
-    return value * config["value"]
+    if config.get("value") in [None, ""]:
+        return value
+    elif isinstance(value, float):
+        return value * float(config["value"])
+    elif isinstance(value, int):
+        return value * int(config["value"])

--- a/transforms/multiplyfield/test_transform.py
+++ b/transforms/multiplyfield/test_transform.py
@@ -29,6 +29,9 @@ def test_no_field():
         transform.transform(15, {}, {"fieldName": "number"})
 
 
+def test_null_config():
+    assert transform.transform(15, {}, {"fieldName": None}) == 15
+
+
 def test_no_config():
-    with pytest.raises(KeyError):
-        transform.transform(15, {}, {})
+    assert transform.transform(15, {}, {}) == 15

--- a/transforms/multiplyfield/transform.py
+++ b/transforms/multiplyfield/transform.py
@@ -1,2 +1,4 @@
 def transform(value, row: dict, config: dict):
+    if config.get("fieldName") in [None, ""]:
+        return value
     return value * row[config["fieldName"]]

--- a/transforms/prependfield/test_transform.py
+++ b/transforms/prependfield/test_transform.py
@@ -28,6 +28,15 @@ def test_prepend_empty_field():
         transform.transform("data streaming", {}, {"fieldName": "prefix"})
 
 
+def test_null_config():
+    assert (
+        transform.transform("data streaming", {"prefix": "Python"}, {"fieldName": None})
+        == "data streaming"
+    )
+
+
 def test_no_config():
-    with pytest.raises(KeyError):
+    assert (
         transform.transform("data streaming", {"prefix": "Python"}, {})
+        == "data streaming"
+    )

--- a/transforms/prependfield/transform.py
+++ b/transforms/prependfield/transform.py
@@ -1,4 +1,6 @@
 def transform(value: str, row: dict, config: dict) -> str:
+    if config.get("fieldName") in [None, ""]:
+        return value
     # See performance of string concatenation in Python:
     # https://stackoverflow.com/questions/12169839/which-is-the-preferred-way-to-concatenate-a-string-in-python/12171382#12171382
     return row[config["fieldName"]] + value

--- a/transforms/prependvalue/test_transform.py
+++ b/transforms/prependvalue/test_transform.py
@@ -18,6 +18,11 @@ def test_prepend_empty_string():
     assert transform.transform("data streaming", {}, {"value": ""}) == "data streaming"
 
 
+def test_null_config():
+    assert (
+        transform.transform("data streaming", {}, {"value": None}) == "data streaming"
+    )
+
+
 def test_no_config():
-    with pytest.raises(KeyError):
-        transform.transform("data streaming", {}, {})
+    assert transform.transform("data streaming", {}, {}) == "data streaming"

--- a/transforms/prependvalue/transform.py
+++ b/transforms/prependvalue/transform.py
@@ -1,4 +1,6 @@
 def transform(value: str, row: dict, config: dict) -> str:
+    if config.get("value") is None:
+        return value
     # See performance of string concatenation in Python:
     # https://stackoverflow.com/questions/12169839/which-is-the-preferred-way-to-concatenate-a-string-in-python/12171382#12171382
     return config["value"] + value

--- a/transforms/renamekeyjsonstructure/test_transform.py
+++ b/transforms/renamekeyjsonstructure/test_transform.py
@@ -24,9 +24,12 @@ def test_rename_key_in_nested_structure():
 
 
 def test_no_config():
-    with pytest.raises(KeyError):
+    json_obj = '{"info": { "name": "DataCater GmbH" }, "url": "https://datacater.io"}'
+    assert (
         transform.transform(
-            '{"info": { "name": "DataCater GmbH" }, "url": "https://datacater.io"}',
+            json_obj,
             {},
             {},
         )
+        == json_obj
+    )

--- a/transforms/renamekeyjsonstructure/transform.py
+++ b/transforms/renamekeyjsonstructure/transform.py
@@ -1,6 +1,9 @@
 def transform(value: str, row: dict, config: dict) -> str:
     import json
 
+    if config.get("oldKeyName") in [None, ""] or config.get("newKeyName") in [None, ""]:
+        return value
+
     def rename_hook(obj):
         for key in list(obj):
             new_key = key.replace(config["oldKeyName"], config["newKeyName"])

--- a/transforms/replaceconstant/test_transform.py
+++ b/transforms/replaceconstant/test_transform.py
@@ -15,5 +15,4 @@ def test_returns_value_none():
 
 
 def test_no_config():
-    with pytest.raises(KeyError):
-        assert transform.transform(None, {}, {})
+    assert transform.transform(None, {}, {}) == None

--- a/transforms/replaceconstant/transform.py
+++ b/transforms/replaceconstant/transform.py
@@ -1,2 +1,4 @@
 def transform(value, row: dict, config: dict):
+    if config.get("value") is None:
+        return value
     return config["value"]

--- a/transforms/replacefield/test_transform.py
+++ b/transforms/replacefield/test_transform.py
@@ -22,5 +22,4 @@ def test_returns_value_field_does_not_exist():
 
 
 def test_no_config():
-    with pytest.raises(KeyError):
-        assert transform.transform(None, {}, {})
+    assert transform.transform(None, {}, {}) == None

--- a/transforms/replacefield/transform.py
+++ b/transforms/replacefield/transform.py
@@ -1,2 +1,4 @@
 def transform(value, row, config):
+    if config.get("fieldName") is None:
+        return value
     return row[config["fieldName"]]

--- a/transforms/round/test_transform.py
+++ b/transforms/round/test_transform.py
@@ -22,6 +22,9 @@ def test_round_precision_passed_as_string():
     assert transform.transform(8.13472, {}, {"precision": "3"}) == 8.135
 
 
+def test_null_config():
+    assert transform.transform(8.14, {}, {"precision": None}) == 8.14
+
+
 def test_no_config():
-    with pytest.raises(KeyError):
-        assert transform.transform(8.14, {}, {})
+    assert transform.transform(8.14, {}, {}) == 8.14

--- a/transforms/round/transform.py
+++ b/transforms/round/transform.py
@@ -1,2 +1,4 @@
 def transform(value, row: dict, config: dict):
+    if config.get("precision") in [None, ""]:
+        return value
     return round(value, int(config["precision"]))

--- a/transforms/subtract/test_transform.py
+++ b/transforms/subtract/test_transform.py
@@ -6,6 +6,10 @@ def test_subtract_int_from_int():
     assert transform.transform(15, {}, {"value": 3}) == 12
 
 
+def test_subtract_int_from_int_string():
+    assert transform.transform(15, {}, {"value": "3"}) == 12
+
+
 def test_subtract_int_from_float():
     assert transform.transform(15.0, {}, {"value": 3}) == 12
 
@@ -18,11 +22,13 @@ def test_subtract_float_from_float():
     assert round(transform.transform(15.3, {}, {"value": 3.1}), 1) == 12.2
 
 
-def test_subtract_string_from_int():
-    with pytest.raises(TypeError):
-        transform.transform(15, {}, {"value": "3"})
+def test_subtract_float_from_float_string():
+    assert round(transform.transform(15.3, {}, {"value": "3.1"}), 1) == 12.2
+
+
+def test_null_config():
+    assert transform.transform(15, {}, {"value": None}) == 15
 
 
 def test_no_config():
-    with pytest.raises(KeyError):
-        transform.transform(15, {}, {})
+    assert transform.transform(15, {}, {}) == 15

--- a/transforms/subtract/transform.py
+++ b/transforms/subtract/transform.py
@@ -1,2 +1,7 @@
 def transform(value, row: dict, config: dict):
-    return value - config["value"]
+    if config.get("value") in [None, ""]:
+        return value
+    elif isinstance(value, float):
+        return value - float(config["value"])
+    elif isinstance(value, int):
+        return value - int(config["value"])

--- a/transforms/subtractfield/test_transform.py
+++ b/transforms/subtractfield/test_transform.py
@@ -27,6 +27,9 @@ def test_subtract_string_from_int():
         transform.transform(15, {"magicNumber": "2"}, {"fieldName": "magicNumber"})
 
 
+def test_null_config():
+    assert transform.transform(15, {"magicNumber": "2"}, {"fieldName": None}) == 15
+
+
 def test_no_config():
-    with pytest.raises(KeyError):
-        transform.transform(15, {"magicNumber": "2"}, {})
+    assert transform.transform(15, {"magicNumber": "2"}, {}) == 15

--- a/transforms/subtractfield/transform.py
+++ b/transforms/subtractfield/transform.py
@@ -1,2 +1,4 @@
 def transform(value, row: dict, config: dict):
+    if config.get("fieldName") in [None, ""]:
+        return value
     return value - row[config["fieldName"]]

--- a/transforms/truncatecharacters/test_transform.py
+++ b/transforms/truncatecharacters/test_transform.py
@@ -44,6 +44,9 @@ def test_truncate_characters_empty_string():
     assert transform.transform("", {}, {"characters": 1000}) == ""
 
 
+def test_null_config():
+    assert transform.transform("", {}, {"characters": None}) == ""
+
+
 def test_no_config():
-    with pytest.raises(KeyError):
-        transform.transform("", {}, {})
+    assert transform.transform("", {}, {}) == ""

--- a/transforms/truncatecharacters/transform.py
+++ b/transforms/truncatecharacters/transform.py
@@ -1,4 +1,7 @@
 def transform(value: str, row: dict, config: dict) -> str:
+    if config.get("characters") in [None, ""]:
+        return value
+
     characters = int(config["characters"])
 
     assert characters >= 0

--- a/transforms/truncatewords/test_transform.py
+++ b/transforms/truncatewords/test_transform.py
@@ -53,6 +53,9 @@ def test_truncate_words_empty_string():
     assert transform.transform("", {}, {"words": 1000}) == ""
 
 
+def test_null_config():
+    assert transform.transform("", {}, {"words": None}) == ""
+
+
 def test_no_config():
-    with pytest.raises(KeyError):
-        transform.transform("", {}, {})
+    assert transform.transform("", {}, {}) == ""

--- a/transforms/truncatewords/transform.py
+++ b/transforms/truncatewords/transform.py
@@ -1,4 +1,7 @@
 def transform(value: str, row: dict, config: dict) -> str:
+    if config.get("words") in [None, ""]:
+        return value
+
     token = config.get("token", " ")
     words = int(config["words"])
 


### PR DESCRIPTION
Increase the robustness of the pre-defined filters and transforms towards absent or wrongly-typed configs.

If the config is absent, try to let the field value pass through where it makes sense.

If the config is wrongly typed, try to adjust the type based on the type inferred from the field value where it makes sense.