### PR TITLE
Optionally preview filtered out records

### DIFF
--- a/python-runner/runner.py
+++ b/python-runner/runner.py
@@ -220,7 +220,7 @@ def preview_pipeline(record: dict, pipeline: dict, preview_step=None):
                     if record_matches_filter is False and (
                         record_transform is None or record_transform.get("key") is None
                     ):
-                        return add_filtered_out_at_step(record, step_index)
+                        return add_filtered_out_at_step(record, step_index, preview_step)
 
                 # Apply transform only if no filter is defined or record matches filter
                 if (
@@ -259,7 +259,7 @@ def preview_pipeline(record: dict, pipeline: dict, preview_step=None):
                                 field_transform is None
                                 or field_transform.get("key") is None
                             ):
-                                return add_filtered_out_at_step(record, step_index)
+                                return add_filtered_out_at_step(record, step_index, preview_step)
 
                         # Apply transform only if no filter is defined or field matches filter
                         if (
@@ -368,11 +368,14 @@ def add_error_to_metadata(record, location, error_type, traceback):
     return record
 
 
-def add_filtered_out_at_step(record, step_index):
-    record["metadata"] = {
-        "filteredOutAtStep": step_index
-    }
-    return record
+def add_filtered_out_at_step(record, step_index, preview_step):
+    if preview_step is None or step_index == preview_step:
+        record["metadata"] = {
+            "filteredOutAtStep": step_index
+        }
+        return record
+    else:
+        return None
 
 
 @app.post("/batch")
@@ -407,7 +410,8 @@ async def preview(previewRequest: PreviewRequest, response: Response):
         processed_record = preview_pipeline(
             record, previewRequest.pipeline, previewRequest.previewStep
         )
-        processed_records.append(processed_record)
+        if processed_record is not None:
+            processed_records.append(processed_record)
     return processed_records
 
 

--- a/python-runner/runner.py
+++ b/python-runner/runner.py
@@ -220,7 +220,7 @@ def preview_pipeline(record: dict, pipeline: dict, preview_step=None):
                     if record_matches_filter is False and (
                         record_transform is None or record_transform.get("key") is None
                     ):
-                        return None
+                        return add_filtered_out_at_step(record, step_index)
 
                 # Apply transform only if no filter is defined or record matches filter
                 if (
@@ -259,7 +259,7 @@ def preview_pipeline(record: dict, pipeline: dict, preview_step=None):
                                 field_transform is None
                                 or field_transform.get("key") is None
                             ):
-                                return None
+                                return add_filtered_out_at_step(record, step_index)
 
                         # Apply transform only if no filter is defined or field matches filter
                         if (
@@ -368,6 +368,13 @@ def add_error_to_metadata(record, location, error_type, traceback):
     return record
 
 
+def add_filtered_out_at_step(record, step_index):
+    record["metadata"] = {
+        "filteredOutAtStep": step_index
+    }
+    return record
+
+
 @app.post("/batch")
 async def apply_to_multiple_records(records: List[dict], response: Response):
     processed_records = []
@@ -400,8 +407,7 @@ async def preview(previewRequest: PreviewRequest, response: Response):
         processed_record = preview_pipeline(
             record, previewRequest.pipeline, previewRequest.previewStep
         )
-        if processed_record is not None:
-            processed_records.append(processed_record)
+        processed_records.append(processed_record)
     return processed_records
 
 

--- a/python-runner/test_runner.py
+++ b/python-runner/test_runner.py
@@ -369,6 +369,11 @@ def test_preview_apply_filter():
             "key": {},
             "value": {"company": "DataCater GmbH"},
             "metadata": {"lastChange": {"key": {}, "value": {}}},
+        },
+        {
+            "key": {},
+            "value": {"company": "DataKater GmbH"},
+            "metadata": {"filteredOutAtStep": 0},
         }
     ]
 
@@ -382,6 +387,9 @@ def test_preview_apply_user_defined_filter():
             "pipeline": {
                 "spec": {
                     "steps": [
+                        {
+                            "kind": "Record"
+                        },
                         {
                             "kind": "Field",
                             "fields": {
@@ -406,6 +414,11 @@ def test_preview_apply_user_defined_filter():
     )
 
     assert response.json() == [
+        {
+            "key": {},
+            "value": {"company": "DataCater GmbH"},
+            "metadata": {"filteredOutAtStep": 1},
+        },
         {
             "key": {},
             "value": {"company": "DataKater GmbH"},
@@ -512,6 +525,31 @@ def test_preview_filter_transform_combination():
             "value": {"company": "DataKater GmbH"},
             "metadata": {"lastChange": {"key": {}, "value": {}}},
         },
+    ]
+
+    assert response.status_code == 200
+
+
+def test_preview_empty_pipeline():
+    response = client.post(
+        "/preview",
+        json={
+            "pipeline": {
+                "spec": {
+                    "steps": [
+                    ]
+                }
+            },
+            "records": [
+                {"key": {}, "value": {"company": "DataCater GmbH"}, "metadata": {}},
+                {"key": {}, "value": {"company": "DataKater GmbH"}, "metadata": {}},
+            ],
+        },
+    )
+
+    assert response.json() == [
+            {"key": {}, "value": {"company": "DataCater GmbH"}, "metadata": {}},
+            {"key": {}, "value": {"company": "DataKater GmbH"}, "metadata": {}},
     ]
 
     assert response.status_code == 200

--- a/ui/src/components/pipelines/PipelineDesigner.js
+++ b/ui/src/components/pipelines/PipelineDesigner.js
@@ -214,9 +214,13 @@ class PipelineDesigner extends Component {
           <ContextSidebar>
             <PreviewSettings
               hideContextBarFunc={this.props.hideContextBarFunc}
+              hideFilteredOutRecords={this.props.hideFilteredOutRecords}
               inspectLimit={this.props.inspectLimit}
               pipeline={this.props.pipeline}
               showGrid={this.state.showGrid}
+              toggleHideFilteredOutRecordsFunc={
+                this.props.toggleHideFilteredOutRecordsFunc
+              }
               toggleShowGridFunc={this.toggleShowGrid}
               updateInspectLimitFunc={this.props.updateInspectLimitFunc}
             />

--- a/ui/src/components/pipelines/pipeline_designer/Grid.js
+++ b/ui/src/components/pipelines/pipeline_designer/Grid.js
@@ -54,6 +54,8 @@ class Grid extends Component {
       }
     }
 
+    let title = "" + rawValue;
+
     // Check whether the field has been changed in the current or a previous step
     const lastChange = sample["metadata"]["lastChange"];
     if (
@@ -68,6 +70,15 @@ class Grid extends Component {
       }
     }
 
+    // Check whether the record has been changed in the current or a previous step
+    const filteredOutAtStep = sample["metadata"]["filteredOutAtStep"];
+    if (filteredOutAtStep !== undefined) {
+      if (filteredOutAtStep + 1 === column.currentStep) {
+        classNames += " filtered-out-in-current-step text-black-50";
+        title = "This record does not pass one of the filters of this step.";
+      }
+    }
+
     if (
       this.props.editColumnField !== undefined &&
       this.props.editColumnField.name === field
@@ -76,7 +87,7 @@ class Grid extends Component {
     }
 
     return (
-      <div className={classNames} key={fieldName} title={"" + rawValue}>
+      <div className={classNames} key={fieldName} title={title}>
         {renderTableCellContent(rawValue)}
       </div>
     );

--- a/ui/src/components/pipelines/pipeline_designer/context_bar/PreviewSettings.js
+++ b/ui/src/components/pipelines/pipeline_designer/context_bar/PreviewSettings.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import { Button } from "react-bootstrap";
-import { Check, Code, Settings, Table } from "react-feather";
+import { Check, Code, Eye, EyeOff, Settings, Table } from "react-feather";
 
 class PreviewSettings extends Component {
   constructor(props) {
@@ -22,9 +22,11 @@ class PreviewSettings extends Component {
 
   render() {
     const {
+      hideFilteredOutRecords,
       inspectLimit,
       pipeline,
       showGrid,
+      toggleHideFilteredOutRecordsFunc,
       toggleShowGridFunc,
       updateInspectLimitFunc,
     } = this.props;
@@ -34,6 +36,14 @@ class PreviewSettings extends Component {
       : "btn btn-sm w-50 btn-outline-primary-soft";
 
     const rawButtonClassNames = !showGrid
+      ? "btn btn-sm w-50 btn-primary-soft"
+      : "btn btn-sm w-50 btn-outline-primary-soft";
+
+    const hideFilteredOutRecordsButtonClassNames = hideFilteredOutRecords
+      ? "btn btn-sm w-50 btn-primary-soft"
+      : "btn btn-sm w-50 btn-outline-primary-soft";
+
+    const showFilteredOutRecordsButtonClassNames = !hideFilteredOutRecords
       ? "btn btn-sm w-50 btn-primary-soft"
       : "btn btn-sm w-50 btn-outline-primary-soft";
 
@@ -124,6 +134,50 @@ class PreviewSettings extends Component {
                 <p className="text-start">
                   Shows the complete sample records, including their values,
                   their keys, and their metadata, in a text view.
+                </p>
+              </a>
+            </div>
+          </div>
+          <div className="mb-4">
+            <h6 className="fw-bold">Filtered out records</h6>
+            <div className="btn-group w-100 mt-2">
+              <a
+                href={`/pipelines/${pipeline.uuid}/edit`}
+                onClick={toggleHideFilteredOutRecordsFunc}
+                className={hideFilteredOutRecordsButtonClassNames}
+              >
+                <h6 className="mt-2 clearfix">
+                  <span className="float-start d-flex align-items-center ms-n1">
+                    <EyeOff className="feather-icon me-1" /> Hide
+                  </span>
+                  {hideFilteredOutRecords && (
+                    <span className="float-end">
+                      <Check className="feather-icon" />
+                    </span>
+                  )}
+                </h6>
+                <p className="text-start">
+                  Hide records that have been filtered out by the pipeline.
+                </p>
+              </a>
+              <a
+                href={`/pipelines/${pipeline.uuid}/edit`}
+                onClick={toggleHideFilteredOutRecordsFunc}
+                className={showFilteredOutRecordsButtonClassNames}
+              >
+                <h6 className="mt-2 clearfix">
+                  <span className="float-start d-flex align-items-center ms-n1">
+                    <Eye className="feather-icon me-1" /> Show
+                  </span>
+                  {!hideFilteredOutRecords && (
+                    <span className="float-end">
+                      <Check className="feather-icon" />
+                    </span>
+                  )}
+                </h6>
+                <p className="text-start">
+                  Show records that have been filtered out by the previewed step
+                  and highlight them in gray.
                 </p>
               </a>
             </div>

--- a/ui/src/components/pipelines/pipeline_designer/grid/Toolbar.js
+++ b/ui/src/components/pipelines/pipeline_designer/grid/Toolbar.js
@@ -93,6 +93,13 @@ class Toolbar extends Component {
       filter = this.props.filters.find((filter) => filter.key === filterKey);
     }
 
+    // Do not include filtered out records in the size of the sample set
+    const sampleRecordsLength = sampleRecords.filter(
+      (record) =>
+        record["metadata"] === undefined ||
+        record["metadata"]["filteredOutAtStep"] === undefined
+    ).length;
+
     return (
       <div className="container mb-2">
         <div className="row align-items-center">
@@ -179,8 +186,8 @@ class Toolbar extends Component {
             )}
             <span className="mx-4">
               {streamInspectLength !== undefined &&
-                sampleRecords.length < streamInspectLength && (
-                  <>{sampleRecords.length} of </>
+                sampleRecordsLength < streamInspectLength && (
+                  <>{sampleRecordsLength} of </>
                 )}
               {streamInspectLength} records
             </span>

--- a/ui/src/containers/pipelines/EditPipeline.js
+++ b/ui/src/containers/pipelines/EditPipeline.js
@@ -47,6 +47,7 @@ class EditPipeline extends Component {
       currentStep: undefined,
       debugRecord: undefined,
       errorMessage: "",
+      hideFilteredOutRecords: true,
       inspectLimit: 100,
       pipeline: {},
       pipelineUpdated: false,
@@ -79,6 +80,8 @@ class EditPipeline extends Component {
     this.closeDebugView = this.closeDebugView.bind(this);
     this.updateInspectLimit = this.updateInspectLimit.bind(this);
     this.toggleShowSettings = this.toggleShowSettings.bind(this);
+    this.toggleHideFilteredOutRecords =
+      this.toggleHideFilteredOutRecords.bind(this);
   }
 
   componentDidMount() {
@@ -716,6 +719,14 @@ class EditPipeline extends Component {
     }
   }
 
+  toggleHideFilteredOutRecords(event) {
+    event.preventDefault();
+
+    this.setState({
+      hideFilteredOutRecords: !this.state.hideFilteredOutRecords,
+    });
+  }
+
   render() {
     const pipeline = this.state.pipeline;
 
@@ -840,14 +851,30 @@ class EditPipeline extends Component {
       );
     }
 
-    let sampleRecords =
+    let sampleRecords = [];
+
+    if (
       this.state.currentStep === undefined ||
       this.props.pipelines.inspectionResult === undefined
-        ? deepCopy(this.props.streams.inspectionResult)
-        : deepCopy(this.props.pipelines.inspectionResult);
+    ) {
+      if (Array.isArray(this.props.streams.inspectionResult)) {
+        sampleRecords = deepCopy(this.props.streams.inspectionResult);
+      }
+    } else {
+      if (Array.isArray(this.props.pipelines.inspectionResult)) {
+        sampleRecords = deepCopy(this.props.pipelines.inspectionResult);
 
-    if (!Array.isArray(sampleRecords)) {
-      sampleRecords = [];
+        // If the user wants to hide filtered out records (which is the default),
+        // we should exclude them from the sample records
+        if (this.state.hideFilteredOutRecords) {
+          sampleRecords = sampleRecords.filter(
+            (record) =>
+              record.metadata === undefined ||
+              (record.metadata !== undefined &&
+                record.metadata["filteredOutAtStep"] === undefined)
+          );
+        }
+      }
     }
 
     const streamInspectLength =
@@ -902,6 +929,7 @@ class EditPipeline extends Component {
             handleFilterChangeFunc={this.handleFilterChange}
             handleStepChangeFunc={this.handleStepChange}
             hideContextBarFunc={this.hideContextBar}
+            hideFilteredOutRecords={this.state.hideFilteredOutRecords}
             hideStepNameFormFunc={this.hideStepNameForm}
             inspectLimit={this.state.inspectLimit}
             moveToStepFunc={this.moveToStep}
@@ -916,6 +944,7 @@ class EditPipeline extends Component {
             showStepNameForm={this.state.showStepNameForm}
             showStepNameFormFunc={this.showStepNameForm}
             streamInspectLength={streamInspectLength}
+            toggleHideFilteredOutRecordsFunc={this.toggleHideFilteredOutRecords}
             toggleShowSettingsFunc={this.toggleShowSettings}
             transforms={this.props.transforms.transforms}
             updateInspectLimitFunc={this.updateInspectLimit}

--- a/ui/src/helpers/profileRecords.js
+++ b/ui/src/helpers/profileRecords.js
@@ -55,7 +55,15 @@ export function profileRecords(records, transformedFields) {
     profile[field].mostFrequentValues = [];
   });
 
-  records.forEach(function (record) {
+  records.forEach((record) => {
+    // Ignore records that have been filtered out for profiling
+    if (
+      record["metadata"] !== undefined &&
+      record["metadata"]["filteredOutAtStep"] !== undefined
+    ) {
+      return;
+    }
+
     const recordValue = record["value"];
     Object.keys(recordValue).forEach(function (fieldName) {
       const value = recordValue[fieldName];

--- a/ui/src/reducers/deployments.js
+++ b/ui/src/reducers/deployments.js
@@ -96,11 +96,9 @@ const deployments = (state, action) => {
         logMessages: [],
       };
     case "RECEIVE_LOGS_DEPLOYMENT":
-      const logMessages = action.logMessages
-        .slice(-101, -1)
-        .map((logLine) => {
-          return JSON.parse(logLine);
-        });
+      const logMessages = action.logMessages.slice(-101, -1).map((logLine) => {
+        return JSON.parse(logLine);
+      });
       return {
         ...state,
         errorMessage: undefined,

--- a/ui/src/scss/grid.scss
+++ b/ui/src/scss/grid.scss
@@ -186,6 +186,10 @@ $row-hovered-background-color: #f5f5f5;
     .sample-cell.error-in-previous-step {
       background-color: #f5b7b1;
     }
+
+    .sample-cell.filtered-out-in-current-step {
+      background-color: #ddd;
+    }
   }
 
   &-filters &__table-main &__row-cell,


### PR DESCRIPTION
Introduce a new preview setting that allows users to enable previewing filtered-out records.

The default behavior of the pipeline designer remains the same. It does not show filtered-out records:
![Screenshot 2023-01-13 at 08 35 00](https://user-images.githubusercontent.com/128683/212264129-03b373e5-51fe-4e18-9b15-a0a957bce023.png)

If the user has enabled showing filtered-out records in the preview settings, we will show them with a gray background:
![Screenshot 2023-01-13 at 08 35 11](https://user-images.githubusercontent.com/128683/212264163-e51ae602-0be5-4c3a-946c-36b2ad968f89.png)

Note that we show filtered-out records only at the step that filters out the records. At successive steps, we will not show them in the UI to avoid confusing the user.