### PR TITLE
fix(ui): Ignore records with null values when profiling sample data

### DIFF
--- a/ui/src/helpers/profileRecords.js
+++ b/ui/src/helpers/profileRecords.js
@@ -65,6 +65,12 @@ export function profileRecords(records, transformedFields) {
     }
 
     const recordValue = record["value"];
+
+    // Ignore records with null values (tombstone records)
+    if (recordValue == null) {
+      return;
+    }
+
     Object.keys(recordValue).forEach(function (fieldName) {
       const value = recordValue[fieldName];
       if (profile[fieldName] === undefined) {


### PR DESCRIPTION
When profiling the sample records in the frontend, we should ignore records with a `null` value to fix the following error:

```
Uncaught TypeError: can't convert null to object
    profileRecords profileRecords.js:74
    profileRecords profileRecords.js:58
    render InspectStream.js:216