### PR TITLE
Fix previewing records with null keys or values

### DIFF
--- a/python-runner/runner.py
+++ b/python-runner/runner.py
@@ -321,12 +321,12 @@ def preview_pipeline(record: dict, pipeline: dict, preview_step=None):
             # Check which fields of the key have been changed by this step
             if type(record["key"]) is dict:
                 for key in record["key"].keys():
-                    if record["key"].get(key) != old_record["key"].get(key):
+                    if old_record["key"] is None or record["key"].get(key) != old_record["key"].get(key):
                         record["metadata"]["lastChange"]["key"][key] = step_index
             # Check which fields of the value have been changed by this step
             if type(record["value"]) is dict:
                 for key in record["value"].keys():
-                    if record["value"].get(key) != old_record["value"].get(key):
+                    if old_record["value"] is None or record["value"].get(key) != old_record["value"].get(key):
                         record["metadata"]["lastChange"]["value"][key] = step_index
 
             if preview_step == step_index:

--- a/python-runner/runner.py
+++ b/python-runner/runner.py
@@ -220,7 +220,9 @@ def preview_pipeline(record: dict, pipeline: dict, preview_step=None):
                     if record_matches_filter is False and (
                         record_transform is None or record_transform.get("key") is None
                     ):
-                        return add_filtered_out_at_step(record, step_index, preview_step)
+                        return add_filtered_out_at_step(
+                            record, step_index, preview_step
+                        )
 
                 # Apply transform only if no filter is defined or record matches filter
                 if (
@@ -259,7 +261,9 @@ def preview_pipeline(record: dict, pipeline: dict, preview_step=None):
                                 field_transform is None
                                 or field_transform.get("key") is None
                             ):
-                                return add_filtered_out_at_step(record, step_index, preview_step)
+                                return add_filtered_out_at_step(
+                                    record, step_index, preview_step
+                                )
 
                         # Apply transform only if no filter is defined or field matches filter
                         if (
@@ -321,12 +325,16 @@ def preview_pipeline(record: dict, pipeline: dict, preview_step=None):
             # Check which fields of the key have been changed by this step
             if type(record["key"]) is dict:
                 for key in record["key"].keys():
-                    if old_record["key"] is None or record["key"].get(key) != old_record["key"].get(key):
+                    if old_record["key"] is None or record["key"].get(
+                        key
+                    ) != old_record["key"].get(key):
                         record["metadata"]["lastChange"]["key"][key] = step_index
             # Check which fields of the value have been changed by this step
             if type(record["value"]) is dict:
                 for key in record["value"].keys():
-                    if old_record["value"] is None or record["value"].get(key) != old_record["value"].get(key):
+                    if old_record["value"] is None or record["value"].get(
+                        key
+                    ) != old_record["value"].get(key):
                         record["metadata"]["lastChange"]["value"][key] = step_index
 
             if preview_step == step_index:
@@ -370,9 +378,7 @@ def add_error_to_metadata(record, location, error_type, traceback):
 
 def add_filtered_out_at_step(record, step_index, preview_step):
     if preview_step is None or step_index == preview_step:
-        record["metadata"] = {
-            "filteredOutAtStep": step_index
-        }
+        record["metadata"] = {"filteredOutAtStep": step_index}
         return record
     else:
         return None

--- a/python-runner/test_runner.py
+++ b/python-runner/test_runner.py
@@ -374,7 +374,7 @@ def test_preview_apply_filter():
             "key": {},
             "value": {"company": "DataKater GmbH"},
             "metadata": {"filteredOutAtStep": 0},
-        }
+        },
     ]
 
     assert response.status_code == 200
@@ -387,9 +387,7 @@ def test_preview_apply_user_defined_filter():
             "pipeline": {
                 "spec": {
                     "steps": [
-                        {
-                            "kind": "Record"
-                        },
+                        {"kind": "Record"},
                         {
                             "kind": "Field",
                             "fields": {
@@ -402,7 +400,7 @@ def test_preview_apply_user_defined_filter():
                                     }
                                 }
                             },
-                        }
+                        },
                     ]
                 }
             },
@@ -423,7 +421,7 @@ def test_preview_apply_user_defined_filter():
             "key": {},
             "value": {"company": "DataKater GmbH"},
             "metadata": {"lastChange": {"key": {}, "value": {}}},
-        }
+        },
     ]
 
     assert response.status_code == 200
@@ -534,12 +532,7 @@ def test_preview_empty_pipeline():
     response = client.post(
         "/preview",
         json={
-            "pipeline": {
-                "spec": {
-                    "steps": [
-                    ]
-                }
-            },
+            "pipeline": {"spec": {"steps": []}},
             "records": [
                 {"key": {}, "value": {"company": "DataCater GmbH"}, "metadata": {}},
                 {"key": {}, "value": {"company": "DataKater GmbH"}, "metadata": {}},
@@ -548,8 +541,8 @@ def test_preview_empty_pipeline():
     )
 
     assert response.json() == [
-            {"key": {}, "value": {"company": "DataCater GmbH"}, "metadata": {}},
-            {"key": {}, "value": {"company": "DataKater GmbH"}, "metadata": {}},
+        {"key": {}, "value": {"company": "DataCater GmbH"}, "metadata": {}},
+        {"key": {}, "value": {"company": "DataKater GmbH"}, "metadata": {}},
     ]
 
     assert response.status_code == 200


### PR DESCRIPTION
Fix previewing of records with null keys or values in the Python Runner.

When determining whether a pipeline has changed the key or value of a record, let's always assume a change if the key or value has been null before applying the pipeline but is not null after applying the pipeline.
We have to make this assumption since we cannot compare the keys of two dictionaries (old state and new state) given that the old state has not been a dictionary but `null`.

I also applied the `black` code formatter to the `/python-runner` folder. We should make this part of our CI pipeline so we do not forget it again in the future.