### PR TITLE
feat(quarkus): Remove default-users.properties from resources

### DIFF
--- a/platform-api/src/main/resources/default-users.properties
+++ b/platform-api/src/main/resources/default-users.properties
@@ -1,1 +1,0 @@
-admin=admin


### PR DESCRIPTION
This PR removes the file `default-users.properties` from the `resources` folder, so we manage security settings via config files or environment variables.