### PR TITLE
feat(pipeline): Finetune Smallrye config

### DIFF
--- a/pipeline/src/main/resources/application.yml
+++ b/pipeline/src/main/resources/application.yml
@@ -18,12 +18,18 @@ mp       :
   messaging:
     outgoing:
       streamout:
+        batch:
+          size: 100000
+        linger:
+          ms: 100
         merge: true
         connector: smallrye-kafka
         topic: streamout
+        max-inflight-messages: 0
     incoming:
       streamin:
         batch: true
+        commit-strategy: throttled
         connector: smallrye-kafka
         max:
           poll:


### PR DESCRIPTION
Finetune the channel configuration of Smallrye to achieve a more stable performance:

* Allow batching records when sending data to the outgoing channel by setting `batch.size=100000` and `linger.ms=100`.
* Disable buffering of inflight messages in Smallrye by setting `max-inflight-message=0`
* Set `commit-strategy=throttled` to improve the acknowledgement of consumed records