### PR TITLE
fix(ui/streams): Do not overwrite field `id`

### DIFF
--- a/ui/src/containers/streams/InspectStream.js
+++ b/ui/src/containers/streams/InspectStream.js
@@ -80,7 +80,7 @@ class InspectStream extends Component {
           isScrolling,
         }) {
           if (!column.isRowNumber && column.field !== undefined) {
-            const rawValue = rowData[column.fieldName];
+            const rawValue = rowData["value"][column.fieldName];
             return (
               <div className="sample-cell w-100 text-nowrap">
                 {renderTableCellContent(rawValue)}
@@ -216,7 +216,7 @@ class InspectStream extends Component {
     const profile = profileRecords(sampleRecords, []);
 
     const records = sampleRecords.map(function (sample, index) {
-      return Object.assign({}, sample["value"], { id: index + 1 });
+      return Object.assign({}, sample, { id: index + 1 });
     });
 
     // Adjust height of grid if API call is shown,


### PR DESCRIPTION
For the grid view, we use a JavaScript library that requires the row property `id` filled with an unique identifier.

When inspecting a stream that featured a field with the name `id`, we have accidentally overwritten this field with the row id from the JavaScript grid.

This commit fixes this issue such that we no longer overwrite field values of sample records.

Before this fix:

<img width="1624" alt="Screenshot 2023-01-24 at 13 04 15" src="https://user-images.githubusercontent.com/128683/214287138-44cf5967-b6c4-4220-adba-9c47c6c024fc.png">

After this fix:

<img width="1624" alt="Screenshot 2023-01-24 at 13 04 05" src="https://user-images.githubusercontent.com/128683/214287176-96b4ac17-4f2b-445f-ac6a-c541373bbbae.png">
