### PR TITLE
feat(helm): Upgrade to 603ed4

### DIFF
--- a/helm-charts/datacater/Chart.yaml
+++ b/helm-charts/datacater/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
   - name: DataCater
     url: https://datacater.io
 
-appVersion: "2023.1"
+appVersion: "603ed45f1d05c69ab75179fd6f78455f398967bb"

--- a/helm-charts/datacater/values.yaml
+++ b/helm-charts/datacater/values.yaml
@@ -11,7 +11,7 @@ datacater:
     username: datacater
     password: datacater
   deployment:
-    image: "datacater/pipeline:2023.1"
+    image: "datacater/pipeline:603ed45f1d05c69ab75179fd6f78455f398967bb"
   transforms:
     path: "/datacater/transforms"
   filters:
@@ -21,7 +21,7 @@ datacater:
     image:
       repository: "datacater/python-runner"
       pullPolicy: IfNotPresent
-      tag: "2023.1"
+      tag: "603ed45f1d05c69ab75179fd6f78455f398967bb"
     replicas: 10
     serviceName: "pythonrunner"
     resources:
@@ -34,7 +34,7 @@ datacater:
     image:
       repository: datacater/ui
       pullPolicy: IfNotPresent
-      tag: "2023.1"
+      tag: "603ed45f1d05c69ab75179fd6f78455f398967bb"
     service:
       type: ClusterIP
 
@@ -42,7 +42,7 @@ image:
   repository: datacater/datacater
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "2023.1"
+  tag: "603ed45f1d05c69ab75179fd6f78455f398967bb"
 
 # GitHub personal access tokens will be used until we publish to docker io
 # Follow instructions -> https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry

--- a/k8s-manifests/minikube-any-namespace.yaml
+++ b/k8s-manifests/minikube-any-namespace.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/part-of: datacater-0.1.0
     app.kubernetes.io/name: datacater
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "a835f7248af45f92427180f69652d656b92f8ba0"
+    app.kubernetes.io/version: "603ed45f1d05c69ab75179fd6f78455f398967bb"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: datacater/templates/role.yaml
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/part-of: datacater-0.1.0
     app.kubernetes.io/name: "python-runner"
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "a835f7248af45f92427180f69652d656b92f8ba0"
+    app.kubernetes.io/version: "603ed45f1d05c69ab75179fd6f78455f398967bb"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -70,7 +70,7 @@ metadata:
     app.kubernetes.io/part-of: datacater-0.1.0
     app.kubernetes.io/name: "python-runner"
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "nightly-20230105"
+    app.kubernetes.io/version: "603ed45f1d05c69ab75179fd6f78455f398967bb"
 spec:
   selector:
     app.kubernetes.io/name: "python-runner"
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/part-of: datacater-0.1.0
     app.kubernetes.io/name: datacater
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "a835f7248af45f92427180f69652d656b92f8ba0"
+    app.kubernetes.io/version: "603ed45f1d05c69ab75179fd6f78455f398967bb"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -114,7 +114,7 @@ metadata:
     app.kubernetes.io/part-of: datacater-0.1.0
     app.kubernetes.io/name: datacater
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "a835f7248af45f92427180f69652d656b92f8ba0"
+    app.kubernetes.io/version: "603ed45f1d05c69ab75179fd6f78455f398967bb"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -136,7 +136,7 @@ metadata:
     app.kubernetes.io/part-of: datacater-0.1.0
     app.kubernetes.io/name: datacater
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "a835f7248af45f92427180f69652d656b92f8ba0"
+    app.kubernetes.io/version: "603ed45f1d05c69ab75179fd6f78455f398967bb"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -151,7 +151,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: "datacater/ui:a835f7248af45f92427180f69652d656b92f8ba0"
+          image: "datacater/ui:603ed45f1d05c69ab75179fd6f78455f398967bb"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -168,7 +168,7 @@ metadata:
     app.kubernetes.io/part-of: datacater-0.1.0
     app.kubernetes.io/name: "python-runner"
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "a835f7248af45f92427180f69652d656b92f8ba0"
+    app.kubernetes.io/version: "603ed45f1d05c69ab75179fd6f78455f398967bb"
     app.kubernetes.io/managed-by: Helm
 spec:
   serviceName: pythonrunner
@@ -185,12 +185,12 @@ spec:
         app.kubernetes.io/part-of: datacater-0.1.0
         app.kubernetes.io/name: "python-runner"
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "a835f7248af45f92427180f69652d656b92f8ba0"
+        app.kubernetes.io/version: "603ed45f1d05c69ab75179fd6f78455f398967bb"
         app.kubernetes.io/managed-by: Helm
     spec:
       containers:
         - name: python-runner
-          image: "datacater/python-runner:a835f7248af45f92427180f69652d656b92f8ba0"
+          image: "datacater/python-runner:603ed45f1d05c69ab75179fd6f78455f398967bb"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -231,7 +231,7 @@ metadata:
     app.kubernetes.io/part-of: datacater-0.1.0
     app.kubernetes.io/name: "python-runner"
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "nightly-20230105"
+    app.kubernetes.io/version: "603ed45f1d05c69ab75179fd6f78455f398967bb"
 spec:
   serviceName: pythonrunner
   replicas: 5
@@ -246,11 +246,11 @@ spec:
         app.kubernetes.io/part-of: datacater-0.1.0
         app.kubernetes.io/name: "python-runner"
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "nightly-20230105"
+        app.kubernetes.io/version: "603ed45f1d05c69ab75179fd6f78455f398967bb"
     spec:
       containers:
         - name: python-runner
-          image: "datacater/python-runner:a835f7248af45f92427180f69652d656b92f8ba0"
+          image: "datacater/python-runner:603ed45f1d05c69ab75179fd6f78455f398967bb"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -292,7 +292,7 @@ metadata:
     app.kubernetes.io/part-of: datacater-0.1.0
     app.kubernetes.io/name: datacater
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "a835f7248af45f92427180f69652d656b92f8ba0"
+    app.kubernetes.io/version: "603ed45f1d05c69ab75179fd6f78455f398967bb"
     app.kubernetes.io/managed-by: Helm
 spec:
   serviceName: datacater
@@ -316,7 +316,7 @@ spec:
         - name: datacater
           securityContext:
             {}
-          image: "datacater/datacater:a835f7248af45f92427180f69652d656b92f8ba0"
+          image: "datacater/datacater:603ed45f1d05c69ab75179fd6f78455f398967bb"
           imagePullPolicy: IfNotPresent
           env:
             - name: QUARKUS_DATASOURCE_REACTIVE_URL
@@ -330,7 +330,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: DATACATER_DEPLOYMENT_IMAGE
-              value: "datacater/pipeline:a835f7248af45f92427180f69652d656b92f8ba0"
+              value: "datacater/pipeline:603ed45f1d05c69ab75179fd6f78455f398967bb"
             - name: DATACATER_TRANSFORMS_PATH
               value: "/datacater/transforms"
             - name: DATACATER_FILTERS_PATH
@@ -338,7 +338,7 @@ spec:
             - name: DATACATER_PYTHONRUNNER_REPLICAS
               value: "5"
             - name: DATACATER_PYTHONRUNNER_IMAGE_VERSION
-              value: "a835f7248af45f92427180f69652d656b92f8ba0"
+              value: "603ed45f1d05c69ab75179fd6f78455f398967bb"
             - name: QUARKUS_LOG_CONSOLE_JSON
               value: "false"
             - name: DATACATER_PYTHONRUNNER_IMAGE_NAMESPACE

--- a/k8s-manifests/minikube-with-postgres-and-redpanda.yaml
+++ b/k8s-manifests/minikube-with-postgres-and-redpanda.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: datacater
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "nightly-20230105"
+    app.kubernetes.io/version: "603ed45f1d05c69ab75179fd6f78455f398967bb"
 ---
 # Source: datacater/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -61,7 +61,7 @@ metadata:
     app.kubernetes.io/part-of: datacater-0.1.0
     app.kubernetes.io/name: "python-runner"
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "nightly-20230105"
+    app.kubernetes.io/version: "603ed45f1d05c69ab75179fd6f78455f398967bb"
 spec:
   selector:
     app.kubernetes.io/name: "python-runner"
@@ -80,7 +80,7 @@ metadata:
   labels:
     app.kubernetes.io/name: datacater
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "nightly-20230105"
+    app.kubernetes.io/version: "603ed45f1d05c69ab75179fd6f78455f398967bb"
 spec:
   type: ClusterIP
   ports:
@@ -102,7 +102,7 @@ metadata:
   namespace: default
 spec:
   containers:
-    - image: datacater/ui:a835f7248af45f92427180f69652d656b92f8ba0
+    - image: datacater/ui:603ed45f1d05c69ab75179fd6f78455f398967bb
       imagePullPolicy: IfNotPresent
       name: ui
       ports:
@@ -202,7 +202,7 @@ metadata:
     app.kubernetes.io/part-of: datacater-0.1.0
     app.kubernetes.io/name: "python-runner"
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "nightly-20230105"
+    app.kubernetes.io/version: "603ed45f1d05c69ab75179fd6f78455f398967bb"
 spec:
   serviceName: pythonrunner
   replicas: 5
@@ -217,11 +217,11 @@ spec:
         app.kubernetes.io/part-of: datacater-0.1.0
         app.kubernetes.io/name: "python-runner"
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "nightly-20230105"
+        app.kubernetes.io/version: "603ed45f1d05c69ab75179fd6f78455f398967bb"
     spec:
       containers:
         - name: python-runner
-          image: "datacater/python-runner:a835f7248af45f92427180f69652d656b92f8ba0"
+          image: "datacater/python-runner:603ed45f1d05c69ab75179fd6f78455f398967bb"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -261,7 +261,7 @@ metadata:
   labels:
     app.kubernetes.io/name: datacater
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "nightly-20230105"
+    app.kubernetes.io/version: "603ed45f1d05c69ab75179fd6f78455f398967bb"
 spec:
   serviceName: datacater
   replicas: 1
@@ -284,7 +284,7 @@ spec:
         - name: datacater
           securityContext:
             {}
-          image: "datacater/datacater:a835f7248af45f92427180f69652d656b92f8ba0"
+          image: "datacater/datacater:603ed45f1d05c69ab75179fd6f78455f398967bb"
           imagePullPolicy: IfNotPresent
           env:
             - name: QUARKUS_DATASOURCE_REACTIVE_URL
@@ -298,7 +298,7 @@ spec:
             - name: DATACATER_DEPLOYMENT_NAMESPACE
               value: default
             - name: DATACATER_DEPLOYMENT_IMAGE
-              value: datacater/pipeline:a835f7248af45f92427180f69652d656b92f8ba0
+              value: datacater/pipeline:603ed45f1d05c69ab75179fd6f78455f398967bb
             - name: DATACATER_TRANSFORMS_PATH
               value: /datacater/transforms
             - name: DATACATER_FILTERS_PATH
@@ -306,12 +306,12 @@ spec:
             - name: DATACATER_PYTHONRUNNER_REPLICAS
               value: "5"
             - name: DATACATER_PYTHONRUNNER_IMAGE_VERSION
-              value: a835f7248af45f92427180f69652d656b92f8ba0
+              value: 603ed45f1d05c69ab75179fd6f78455f398967bb
             - name: QUARKUS_LOG_CONSOLE_JSON
               value: "false"
               #these thresholds should be raised if your deployments are getting `Java heap Out of memory` exceptions
             - name: DATACATER_DEPLOYMENT_RESOURCES_REQUESTS_MEMORY
-              value: "300Mi"
+              value: "800Mi"
             - name: DATACATER_DEPLOYMENT_RESOURCES_LIMITS_MEMORY
               value: "800Mi"
           ports:

--- a/k8s-manifests/minikube-with-postgres-ns-default.yaml
+++ b/k8s-manifests/minikube-with-postgres-ns-default.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/part-of: datacater-0.1.0
     app.kubernetes.io/name: datacater
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "nightly-20230105"
+    app.kubernetes.io/version: "603ed45f1d05c69ab75179fd6f78455f398967bb"
 ---
 # Source: datacater/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -62,7 +62,7 @@ metadata:
     app.kubernetes.io/part-of: datacater-0.1.0
     app.kubernetes.io/name: "python-runner"
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "nightly-20230105"
+    app.kubernetes.io/version: "603ed45f1d05c69ab75179fd6f78455f398967bb"
 spec:
   selector:
     app.kubernetes.io/name: "python-runner"
@@ -81,7 +81,7 @@ metadata:
   labels:
     app.kubernetes.io/name: datacater
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "nightly-20230105"
+    app.kubernetes.io/version: "603ed45f1d05c69ab75179fd6f78455f398967bb"
 spec:
   type: ClusterIP
   ports:
@@ -103,7 +103,7 @@ metadata:
   namespace: default
 spec:
   containers:
-    - image: datacater/ui:a835f7248af45f92427180f69652d656b92f8ba0
+    - image: datacater/ui:603ed45f1d05c69ab75179fd6f78455f398967bb
       imagePullPolicy: IfNotPresent
       name: ui
       ports:
@@ -203,7 +203,7 @@ metadata:
     app.kubernetes.io/part-of: datacater-0.1.0
     app.kubernetes.io/name: "python-runner"
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "nightly-20230105"
+    app.kubernetes.io/version: "603ed45f1d05c69ab75179fd6f78455f398967bb"
 spec:
   serviceName: pythonrunner
   replicas: 5
@@ -218,11 +218,11 @@ spec:
         app.kubernetes.io/part-of: datacater-0.1.0
         app.kubernetes.io/name: "python-runner"
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "nightly-20230105"
+        app.kubernetes.io/version: "603ed45f1d05c69ab75179fd6f78455f398967bb"
     spec:
       containers:
         - name: python-runner
-          image: "datacater/python-runner:a835f7248af45f92427180f69652d656b92f8ba0"
+          image: "datacater/python-runner:603ed45f1d05c69ab75179fd6f78455f398967bb"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -262,7 +262,7 @@ metadata:
   labels:
     app.kubernetes.io/name: datacater
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "nightly-20230105"
+    app.kubernetes.io/version: "603ed45f1d05c69ab75179fd6f78455f398967bb"
 spec:
   serviceName: datacater
   replicas: 1
@@ -285,7 +285,7 @@ spec:
         - name: datacater
           securityContext:
             {}
-          image: "datacater/datacater:a835f7248af45f92427180f69652d656b92f8ba0"
+          image: "datacater/datacater:603ed45f1d05c69ab75179fd6f78455f398967bb"
           imagePullPolicy: IfNotPresent
           env:
             - name: QUARKUS_DATASOURCE_REACTIVE_URL
@@ -299,7 +299,7 @@ spec:
             - name: DATACATER_DEPLOYMENT_NAMESPACE
               value: default
             - name: DATACATER_DEPLOYMENT_IMAGE
-              value: datacater/pipeline:a835f7248af45f92427180f69652d656b92f8ba0
+              value: datacater/pipeline:603ed45f1d05c69ab75179fd6f78455f398967bb
             - name: DATACATER_TRANSFORMS_PATH
               value: /datacater/transforms
             - name: DATACATER_FILTERS_PATH
@@ -307,7 +307,7 @@ spec:
             - name: DATACATER_PYTHONRUNNER_REPLICAS
               value: "5"
             - name: DATACATER_PYTHONRUNNER_IMAGE_VERSION
-              value: a835f7248af45f92427180f69652d656b92f8ba0
+              value: 603ed45f1d05c69ab75179fd6f78455f398967bb
             - name: QUARKUS_LOG_CONSOLE_JSON
               value: "false"
           ports:


### PR DESCRIPTION
Upgrade the Helm chart and Kubernetes manifests to `603ed45f1d05c69ab75179fd6f78455f398967bb` to fix a couple of issues with backpressure in the pipelines.