### PR TITLE
fix: reference mount path to pg

### DIFF
--- a/helm-charts/datacater/templates/postgres.yaml
+++ b/helm-charts/datacater/templates/postgres.yaml
@@ -86,7 +86,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 3
           volumeMounts:
-            - mountPath: /var/lib/postgresql/data/pgdata
+            - mountPath: /var/lib/postgresql/data
               name: {{ .Values.postgres.pvc.volumeMountsName | default "postgres"}}
   volumeClaimTemplates:
     - metadata:

--- a/helm-charts/datacater/values.yaml
+++ b/helm-charts/datacater/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 
 datacater:
   database:
-    host: "postgres-postgresql:5432/postgres"
+    host: "postgres:5432/postgres"
     username: datacater
     password: datacater
   deployment:

--- a/k8s-manifests/minikube-any-namespace.yaml
+++ b/k8s-manifests/minikube-any-namespace.yaml
@@ -237,7 +237,7 @@ spec:
           imagePullPolicy: IfNotPresent
           env:
             - name: QUARKUS_DATASOURCE_REACTIVE_URL
-              value: "postgresql://postgres-postgresql:5432/postgres"
+              value: "postgresql://postgres:5432/postgres"
             - name: QUARKUS_DATASOURCE_USERNAME
               value: "datacater"
             - name: QUARKUS_DATASOURCE_PASSWORD

--- a/k8s-manifests/minikube-with-postgres-ns-default.yaml
+++ b/k8s-manifests/minikube-with-postgres-ns-default.yaml
@@ -225,7 +225,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 3
           volumeMounts:
-            - mountPath: /var/lib/postgresql/data/pgdata
+            - mountPath: /var/lib/postgresql/data
               name: postgres
   volumeClaimTemplates:
     - metadata:
@@ -336,7 +336,7 @@ spec:
           imagePullPolicy: IfNotPresent
           env:
             - name: QUARKUS_DATASOURCE_REACTIVE_URL
-              value: "postgresql://postgres-postgresql:5432/postgres"
+              value: "postgresql://postgres:5432/postgres"
             - name: QUARKUS_DATASOURCE_USERNAME
               value: "postgres"
             - name: QUARKUS_DATASOURCE_PASSWORD


### PR DESCRIPTION
The directory for `PGDATA` has to be a sub-directory of the mount path.

Refs:
- https://hub.docker.com/_/postgres