### PR TITLE
fix(ui): Fix previewing tombstone records

### DIFF
--- a/ui/src/components/pipelines/pipeline_designer/Grid.js
+++ b/ui/src/components/pipelines/pipeline_designer/Grid.js
@@ -23,7 +23,8 @@ class Grid extends Component {
 
     const field = column.field;
     const fieldName = field.name;
-    const rawValue = sample["value"][fieldName];
+    const rawValue =
+      sample["value"] == null ? null : sample["value"][fieldName];
 
     // Check whether an error has occured when applying the pipeline spec
     // in the current or a previous step

--- a/ui/src/containers/streams/InspectStream.js
+++ b/ui/src/containers/streams/InspectStream.js
@@ -80,7 +80,10 @@ class InspectStream extends Component {
           isScrolling,
         }) {
           if (!column.isRowNumber && column.field !== undefined) {
-            const rawValue = rowData["value"][column.fieldName];
+            const rawValue =
+              rowData["value"] == null
+                ? null
+                : rowData["value"][column.fieldName];
             return (
               <div className="sample-cell w-100 text-nowrap">
                 {renderTableCellContent(rawValue)}


### PR DESCRIPTION
Fix the previewing of tombstone records, i.e., records whose value is `null`, by rendering all fields as `null` in the grid.