### PR TITLE
fix(stream-inspect): change message retrieval method

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,4 @@ quarkusPlatformArtifactId=quarkus-bom
 quarkusPluginId=io.quarkus
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformVersion=2.12.0.Final
+org.gradle.jvmargs=-Xmx1024m

--- a/platform-api/src/main/java/io/datacater/core/stream/KafkaStreamsAdmin.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/KafkaStreamsAdmin.java
@@ -173,14 +173,14 @@ public class KafkaStreamsAdmin implements StreamService {
    * Inspect (or retrieve) the most recent events of the Topic.
    *
    * @param limit Number of records to retrieve.
-   * @param distributedInspect Mode of operation for the retrieval of records. - true: Distributed
+   * @param distributed Mode of operation for the retrieval of records. - true: Distributed
    *     retrieval. Records are polled evenly across partitions. The return amount can vary
    *     depending on the amount of messages in a partition. - false: Top-down retrieval. Messages
    *     are polled from one partition. If the partition does not contain the amount defined in
    *     `limit`, the next partition is polled and so on.
    * @return a List<StreamMessage> containing the inspected messages form each topic
    */
-  public List<StreamMessage> inspect(Stream stream, long limit, boolean distributedInspect) {
+  public List<StreamMessage> inspect(Stream stream, long limit, boolean distributed) {
     List<StreamMessage> messageList = new ArrayList<>();
     if (!streamExists()) {
       return messageList;
@@ -191,7 +191,7 @@ public class KafkaStreamsAdmin implements StreamService {
     }
     consumer.assign(partitionsList);
 
-    if (distributedInspect) {
+    if (distributed) {
       final long partitionMessageAmount =
           (long) Math.ceil((double) limit / (double) partitionsList.size());
       setPartitionOffsets(partitionsList, partitionMessageAmount);

--- a/platform-api/src/main/java/io/datacater/core/stream/KafkaStreamsAdmin.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/KafkaStreamsAdmin.java
@@ -173,9 +173,15 @@ public class KafkaStreamsAdmin implements StreamService {
    * Inspect (or retrieve) the most recent events of the Topic.
    *
    * @param limit Number of records to retrieve.
+   * @param distributedInspect Mode of operation for the retrieval of records.
+   *      - true: Distributed retrieval. Records are polled evenly across partitions.
+   *              The return amount can vary depending on the amount of messages in a partition.
+   *      - false: Top-down retrieval. Messages are polled from one partition. If the
+   *               partition does not contain the amount defined in `limit`, the next partition
+   *               is polled and so on.
    * @return a List<StreamMessage> containing the inspected messages form each topic
    */
-  public List<StreamMessage> inspect(Stream stream, long limit) {
+  public List<StreamMessage> inspect(Stream stream, long limit, boolean distributedInspect) {
     List<StreamMessage> messageList = new ArrayList<>();
     if (!streamExists()) {
       return messageList;

--- a/platform-api/src/main/java/io/datacater/core/stream/KafkaStreamsAdmin.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/KafkaStreamsAdmin.java
@@ -173,12 +173,11 @@ public class KafkaStreamsAdmin implements StreamService {
    * Inspect (or retrieve) the most recent events of the Topic.
    *
    * @param limit Number of records to retrieve.
-   * @param distributedInspect Mode of operation for the retrieval of records.
-   *      - true: Distributed retrieval. Records are polled evenly across partitions.
-   *              The return amount can vary depending on the amount of messages in a partition.
-   *      - false: Top-down retrieval. Messages are polled from one partition. If the
-   *               partition does not contain the amount defined in `limit`, the next partition
-   *               is polled and so on.
+   * @param distributedInspect Mode of operation for the retrieval of records. - true: Distributed
+   *     retrieval. Records are polled evenly across partitions. The return amount can vary
+   *     depending on the amount of messages in a partition. - false: Top-down retrieval. Messages
+   *     are polled from one partition. If the partition does not contain the amount defined in
+   *     `limit`, the next partition is polled and so on.
    * @return a List<StreamMessage> containing the inspected messages form each topic
    */
   public List<StreamMessage> inspect(Stream stream, long limit, boolean distributedInspect) {

--- a/platform-api/src/main/java/io/datacater/core/stream/KafkaStreamsAdmin.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/KafkaStreamsAdmin.java
@@ -15,7 +15,6 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigResource;
 import org.eclipse.microprofile.config.ConfigProvider;
-import org.jboss.logging.Logger;
 
 /**
  * Implementation of an external Apache Kafka topic as a stream.
@@ -31,7 +30,6 @@ import org.jboss.logging.Logger;
  * href="https://kafka.apache.org/documentation/#topicconfigs">https://kafka.apache.org/documentation/#topicconfigs</a>).
  */
 public class KafkaStreamsAdmin implements StreamService {
-  private static final Logger LOGGER = Logger.getLogger(KafkaStreamsAdmin.class);
   private static final String PARTITION_COUNT = "num.partitions";
   private static final String REPLICATION_FACTOR = "replication.factor";
   private final Admin admin;

--- a/platform-api/src/main/java/io/datacater/core/stream/KafkaStreamsAdmin.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/KafkaStreamsAdmin.java
@@ -173,14 +173,14 @@ public class KafkaStreamsAdmin implements StreamService {
    * Inspect (or retrieve) the most recent events of the Topic.
    *
    * @param limit Number of records to retrieve.
-   * @param distributed Mode of operation for the retrieval of records. - true: Distributed
-   *     retrieval. Records are polled evenly across partitions. The return amount can vary
-   *     depending on the amount of messages in a partition. - false: Top-down retrieval. Messages
-   *     are polled from one partition. If the partition does not contain the amount defined in
-   *     `limit`, the next partition is polled and so on.
+   * @param method Mode of operation for the retrieval of records. - Uniform: Distributed retrieval.
+   *     Records are polled evenly across partitions. The return amount can vary depending on the
+   *     amount of messages in a partition. - Sequenced: Fold-right retrieval. Messages are polled
+   *     from one partition. If the partition does not contain the amount defined in `limit`, the
+   *     next partition is polled and so on.
    * @return a List<StreamMessage> containing the inspected messages form each topic
    */
-  public List<StreamMessage> inspect(Stream stream, long limit, boolean distributed) {
+  public List<StreamMessage> inspect(Stream stream, long limit, SampleMethod method) {
     List<StreamMessage> messageList = new ArrayList<>();
     if (!streamExists()) {
       return messageList;
@@ -191,7 +191,7 @@ public class KafkaStreamsAdmin implements StreamService {
     }
     consumer.assign(partitionsList);
 
-    if (distributed) {
+    if (method == SampleMethod.UNIFORM) {
       final long partitionMessageAmount =
           (long) Math.ceil((double) limit / (double) partitionsList.size());
       setPartitionOffsets(partitionsList, partitionMessageAmount);

--- a/platform-api/src/main/java/io/datacater/core/stream/KafkaStreamsAdmin.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/KafkaStreamsAdmin.java
@@ -173,14 +173,14 @@ public class KafkaStreamsAdmin implements StreamService {
    * Inspect (or retrieve) the most recent events of the Topic.
    *
    * @param limit Number of records to retrieve.
-   * @param method Mode of operation for the retrieval of records. - Uniform: Distributed retrieval.
-   *     Records are polled evenly across partitions. The return amount can vary depending on the
-   *     amount of messages in a partition. - Sequenced: Fold-right retrieval. Messages are polled
-   *     from one partition. If the partition does not contain the amount defined in `limit`, the
-   *     next partition is polled and so on.
+   * @param sampleMethod Mode of operation for the retrieval of records. - Uniform: Distributed
+   *     retrieval. Records are polled evenly across partitions. The return amount can vary
+   *     depending on the amount of messages in a partition. - Sequenced: Fold-right retrieval.
+   *     Messages are polled from one partition. If the partition does not contain the amount
+   *     defined in `limit`, the next partition is polled and so on.
    * @return a List<StreamMessage> containing the inspected messages form each topic
    */
-  public List<StreamMessage> inspect(Stream stream, long limit, SampleMethod method) {
+  public List<StreamMessage> inspect(Stream stream, long limit, SampleMethod sampleMethod) {
     List<StreamMessage> messageList = new ArrayList<>();
     if (!streamExists()) {
       return messageList;
@@ -191,7 +191,7 @@ public class KafkaStreamsAdmin implements StreamService {
     }
     consumer.assign(partitionsList);
 
-    if (method == SampleMethod.UNIFORM) {
+    if (sampleMethod == SampleMethod.UNIFORM) {
       final long partitionMessageAmount =
           (long) Math.ceil((double) limit / (double) partitionsList.size());
       setPartitionOffsets(partitionsList, partitionMessageAmount);

--- a/platform-api/src/main/java/io/datacater/core/stream/SampleMethod.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/SampleMethod.java
@@ -1,0 +1,12 @@
+package io.datacater.core.stream;
+
+public enum SampleMethod {
+  UNIFORM("uniform"),
+  SEQUENCED("sequenced");
+
+  private final String method;
+
+  SampleMethod(String method) {
+    this.method = method;
+  }
+}

--- a/platform-api/src/main/java/io/datacater/core/stream/StreamEndpoint.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/StreamEndpoint.java
@@ -45,8 +45,8 @@ public class StreamEndpoint {
   public Uni<List<StreamMessage>> inspectStream(
       @PathParam("uuid") UUID uuid,
       @DefaultValue("100") @QueryParam("limit") Long limit,
-      @DefaultValue("false") @QueryParam("distributedInspect") boolean distributedInspect) {
-    return streamsUtil.getStreamMessages(uuid, limit, distributedInspect);
+      @DefaultValue("false") @QueryParam("distributed") boolean distributed) {
+    return streamsUtil.getStreamMessages(uuid, limit, distributed);
   }
 
   @GET

--- a/platform-api/src/main/java/io/datacater/core/stream/StreamEndpoint.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/StreamEndpoint.java
@@ -45,8 +45,8 @@ public class StreamEndpoint {
   public Uni<List<StreamMessage>> inspectStream(
       @PathParam("uuid") UUID uuid,
       @DefaultValue("100") @QueryParam("limit") Long limit,
-      @DefaultValue("false") @QueryParam("distributed") boolean distributed) {
-    return streamsUtil.getStreamMessages(uuid, limit, distributed);
+      @DefaultValue("SEQUENCED") @QueryParam("sampleMethod") SampleMethod method) {
+    return streamsUtil.getStreamMessages(uuid, limit, method);
   }
 
   @GET

--- a/platform-api/src/main/java/io/datacater/core/stream/StreamEndpoint.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/StreamEndpoint.java
@@ -43,7 +43,9 @@ public class StreamEndpoint {
   @GET
   @Path("{uuid}/inspect")
   public Uni<List<StreamMessage>> inspectStream(
-      @PathParam("uuid") UUID uuid, @DefaultValue("100") @QueryParam("limit") Long limit, @DefaultValue("false") @QueryParam("distributedInspect") boolean distributedInspect ) {
+      @PathParam("uuid") UUID uuid,
+      @DefaultValue("100") @QueryParam("limit") Long limit,
+      @DefaultValue("false") @QueryParam("distributedInspect") boolean distributedInspect) {
     return streamsUtil.getStreamMessages(uuid, limit, distributedInspect);
   }
 

--- a/platform-api/src/main/java/io/datacater/core/stream/StreamEndpoint.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/StreamEndpoint.java
@@ -45,8 +45,8 @@ public class StreamEndpoint {
   public Uni<List<StreamMessage>> inspectStream(
       @PathParam("uuid") UUID uuid,
       @DefaultValue("100") @QueryParam("limit") Long limit,
-      @DefaultValue("SEQUENCED") @QueryParam("sampleMethod") SampleMethod method) {
-    return streamsUtil.getStreamMessages(uuid, limit, method);
+      @DefaultValue("SEQUENCED") @QueryParam("sampleMethod") SampleMethod sampleMethod) {
+    return streamsUtil.getStreamMessages(uuid, limit, sampleMethod);
   }
 
   @GET

--- a/platform-api/src/main/java/io/datacater/core/stream/StreamEndpoint.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/StreamEndpoint.java
@@ -43,8 +43,8 @@ public class StreamEndpoint {
   @GET
   @Path("{uuid}/inspect")
   public Uni<List<StreamMessage>> inspectStream(
-      @PathParam("uuid") UUID uuid, @DefaultValue("100") @QueryParam("limit") Long limit) {
-    return streamsUtil.getStreamMessages(uuid, limit);
+      @PathParam("uuid") UUID uuid, @DefaultValue("100") @QueryParam("limit") Long limit, @DefaultValue("false") @QueryParam("distributedInspect") boolean distributedInspect ) {
+    return streamsUtil.getStreamMessages(uuid, limit, distributedInspect);
   }
 
   @GET

--- a/platform-api/src/main/java/io/datacater/core/stream/StreamService.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/StreamService.java
@@ -31,14 +31,14 @@ public interface StreamService {
    * Inspect (or retrieve) the most recent events of a stream.
    *
    * @param limit Number of records to retrieve.
-   * @param distributedInspect Mode of operation for the retrieval of records. - true: Distributed
-   *     retrieval. Records are polled evenly across partitions. The return amount can vary
-   *     depending on the amount of messages in a partition. - false: Top-down retrieval. Messages
-   *     are polled from one partition. If the partition does not contain the amount defined in
-   *     `limit`, the next partition is polled and so on.
+   * @param method Mode of operation for the retrieval of records. - Uniform: Distributed retrieval.
+   *     Records are polled evenly across partitions. The return amount can vary depending on the
+   *     amount of messages in a partition. - Sequenced: Top-down retrieval. Messages are polled
+   *     from one partition. If the partition does not contain the amount defined in `limit`, the
+   *     next partition is polled and so on.
    * @return a List<StreamMessage> containing the inspected messages from each stream
    */
-  List<StreamMessage> inspect(Stream stream, long limit, boolean distributed);
+  List<StreamMessage> inspect(Stream stream, long limit, SampleMethod method);
 
   /**
    * Create a Topic with the given specifications.

--- a/platform-api/src/main/java/io/datacater/core/stream/StreamService.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/StreamService.java
@@ -28,7 +28,7 @@ public interface StreamService {
   Map<String, String> getMetadata();
 
   /**
-   * Inspect (or retrieve) the most recent events of the Topic.
+   * Inspect (or retrieve) the most recent events of a stream.
    *
    * @param limit Number of records to retrieve.
    * @param distributedInspect Mode of operation for the retrieval of records. - true: Distributed
@@ -36,7 +36,7 @@ public interface StreamService {
    *     depending on the amount of messages in a partition. - false: Top-down retrieval. Messages
    *     are polled from one partition. If the partition does not contain the amount defined in
    *     `limit`, the next partition is polled and so on.
-   * @return a List<StreamMessage> containing the inspected messages form each topic
+   * @return a List<StreamMessage> containing the inspected messages from each stream
    */
   List<StreamMessage> inspect(Stream stream, long limit, boolean distributedInspect);
 

--- a/platform-api/src/main/java/io/datacater/core/stream/StreamService.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/StreamService.java
@@ -38,7 +38,7 @@ public interface StreamService {
    *     `limit`, the next partition is polled and so on.
    * @return a List<StreamMessage> containing the inspected messages from each stream
    */
-  List<StreamMessage> inspect(Stream stream, long limit, boolean distributedInspect);
+  List<StreamMessage> inspect(Stream stream, long limit, boolean distributed);
 
   /**
    * Create a Topic with the given specifications.

--- a/platform-api/src/main/java/io/datacater/core/stream/StreamService.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/StreamService.java
@@ -28,12 +28,18 @@ public interface StreamService {
   Map<String, String> getMetadata();
 
   /**
-   * Inspect (or retrieve) the most recent events of a stream.
+   * Inspect (or retrieve) the most recent events of the Topic.
    *
    * @param limit Number of records to retrieve.
-   * @return
+   * @param distributedInspect Mode of operation for the retrieval of records.
+   *      - true: Distributed retrieval. Records are polled evenly across partitions.
+   *              The return amount can vary depending on the amount of messages in a partition.
+   *      - false: Top-down retrieval. Messages are polled from one partition. If the
+   *               partition does not contain the amount defined in `limit`, the next partition
+   *               is polled and so on.
+   * @return a List<StreamMessage> containing the inspected messages form each topic
    */
-  List<StreamMessage> inspect(Stream stream, long limit);
+  List<StreamMessage> inspect(Stream stream, long limit, boolean distributedInspect);
 
   /**
    * Create a Topic with the given specifications.

--- a/platform-api/src/main/java/io/datacater/core/stream/StreamService.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/StreamService.java
@@ -31,14 +31,14 @@ public interface StreamService {
    * Inspect (or retrieve) the most recent events of a stream.
    *
    * @param limit Number of records to retrieve.
-   * @param method Mode of operation for the retrieval of records. - Uniform: Distributed retrieval.
-   *     Records are polled evenly across partitions. The return amount can vary depending on the
-   *     amount of messages in a partition. - Sequenced: Top-down retrieval. Messages are polled
-   *     from one partition. If the partition does not contain the amount defined in `limit`, the
-   *     next partition is polled and so on.
+   * @param sampleMethod Mode of operation for the retrieval of records. - Uniform: Distributed
+   *     retrieval. Records are polled evenly across partitions. The return amount can vary
+   *     depending on the amount of messages in a partition. - Sequenced: Top-down retrieval.
+   *     Messages are polled from one partition. If the partition does not contain the amount
+   *     defined in `limit`, the next partition is polled and so on.
    * @return a List<StreamMessage> containing the inspected messages from each stream
    */
-  List<StreamMessage> inspect(Stream stream, long limit, SampleMethod method);
+  List<StreamMessage> inspect(Stream stream, long limit, SampleMethod sampleMethod);
 
   /**
    * Create a Topic with the given specifications.

--- a/platform-api/src/main/java/io/datacater/core/stream/StreamService.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/StreamService.java
@@ -31,12 +31,11 @@ public interface StreamService {
    * Inspect (or retrieve) the most recent events of the Topic.
    *
    * @param limit Number of records to retrieve.
-   * @param distributedInspect Mode of operation for the retrieval of records.
-   *      - true: Distributed retrieval. Records are polled evenly across partitions.
-   *              The return amount can vary depending on the amount of messages in a partition.
-   *      - false: Top-down retrieval. Messages are polled from one partition. If the
-   *               partition does not contain the amount defined in `limit`, the next partition
-   *               is polled and so on.
+   * @param distributedInspect Mode of operation for the retrieval of records. - true: Distributed
+   *     retrieval. Records are polled evenly across partitions. The return amount can vary
+   *     depending on the amount of messages in a partition. - false: Top-down retrieval. Messages
+   *     are polled from one partition. If the partition does not contain the amount defined in
+   *     `limit`, the next partition is polled and so on.
    * @return a List<StreamMessage> containing the inspected messages form each topic
    */
   List<StreamMessage> inspect(Stream stream, long limit, boolean distributedInspect);

--- a/platform-api/src/main/java/io/datacater/core/stream/StreamsUtilities.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/StreamsUtilities.java
@@ -16,11 +16,12 @@ public class StreamsUtilities {
   @Inject DataCaterSessionFactory dsf;
 
   public Uni<List<StreamMessage>> getStreamMessages(UUID uuid) {
-      //TODO what static value would be better here, distributed or not?
+    // TODO what static value would be better here, distributed or not?
     return getStreamMessages(uuid, 100L, false);
   }
 
-  public Uni<List<StreamMessage>> getStreamMessages(UUID uuid, Long limit, boolean distributedInspect) {
+  public Uni<List<StreamMessage>> getStreamMessages(
+      UUID uuid, Long limit, boolean distributedInspect) {
     return dsf.withTransaction(
         ((session, transaction) ->
             session
@@ -36,7 +37,8 @@ public class StreamsUtilities {
                             // parameter `limit`
                             stream.spec().getKafka().put("max.poll.records", limit.intValue());
                             StreamService kafkaAdmin = KafkaStreamsAdmin.from(stream);
-                            List<StreamMessage> messages = kafkaAdmin.inspect(stream, limit, distributedInspect);
+                            List<StreamMessage> messages =
+                                kafkaAdmin.inspect(stream, limit, distributedInspect);
                             kafkaAdmin.close();
                             return messages;
                           } catch (JsonProcessingException ex) {

--- a/platform-api/src/main/java/io/datacater/core/stream/StreamsUtilities.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/StreamsUtilities.java
@@ -16,10 +16,11 @@ public class StreamsUtilities {
   @Inject DataCaterSessionFactory dsf;
 
   public Uni<List<StreamMessage>> getStreamMessages(UUID uuid) {
-    return getStreamMessages(uuid, 100L);
+      //TODO what static value would be better here, distributed or not?
+    return getStreamMessages(uuid, 100L, false);
   }
 
-  public Uni<List<StreamMessage>> getStreamMessages(UUID uuid, Long limit) {
+  public Uni<List<StreamMessage>> getStreamMessages(UUID uuid, Long limit, boolean distributedInspect) {
     return dsf.withTransaction(
         ((session, transaction) ->
             session
@@ -35,7 +36,7 @@ public class StreamsUtilities {
                             // parameter `limit`
                             stream.spec().getKafka().put("max.poll.records", limit.intValue());
                             StreamService kafkaAdmin = KafkaStreamsAdmin.from(stream);
-                            List<StreamMessage> messages = kafkaAdmin.inspect(stream, limit);
+                            List<StreamMessage> messages = kafkaAdmin.inspect(stream, limit, distributedInspect);
                             kafkaAdmin.close();
                             return messages;
                           } catch (JsonProcessingException ex) {

--- a/platform-api/src/main/java/io/datacater/core/stream/StreamsUtilities.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/StreamsUtilities.java
@@ -19,7 +19,8 @@ public class StreamsUtilities {
     return getStreamMessages(uuid, 100L, SampleMethod.SEQUENCED);
   }
 
-  public Uni<List<StreamMessage>> getStreamMessages(UUID uuid, Long limit, SampleMethod method) {
+  public Uni<List<StreamMessage>> getStreamMessages(
+      UUID uuid, Long limit, SampleMethod sampleMethod) {
     return dsf.withTransaction(
         ((session, transaction) ->
             session
@@ -36,7 +37,7 @@ public class StreamsUtilities {
                             stream.spec().getKafka().put("max.poll.records", limit.intValue());
                             StreamService kafkaAdmin = KafkaStreamsAdmin.from(stream);
                             List<StreamMessage> messages =
-                                kafkaAdmin.inspect(stream, limit, method);
+                                kafkaAdmin.inspect(stream, limit, sampleMethod);
                             kafkaAdmin.close();
                             return messages;
                           } catch (JsonProcessingException ex) {

--- a/platform-api/src/main/java/io/datacater/core/stream/StreamsUtilities.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/StreamsUtilities.java
@@ -16,10 +16,10 @@ public class StreamsUtilities {
   @Inject DataCaterSessionFactory dsf;
 
   public Uni<List<StreamMessage>> getStreamMessages(UUID uuid) {
-    return getStreamMessages(uuid, 100L, false);
+    return getStreamMessages(uuid, 100L, SampleMethod.SEQUENCED);
   }
 
-  public Uni<List<StreamMessage>> getStreamMessages(UUID uuid, Long limit, boolean distributed) {
+  public Uni<List<StreamMessage>> getStreamMessages(UUID uuid, Long limit, SampleMethod method) {
     return dsf.withTransaction(
         ((session, transaction) ->
             session
@@ -36,7 +36,7 @@ public class StreamsUtilities {
                             stream.spec().getKafka().put("max.poll.records", limit.intValue());
                             StreamService kafkaAdmin = KafkaStreamsAdmin.from(stream);
                             List<StreamMessage> messages =
-                                kafkaAdmin.inspect(stream, limit, distributed);
+                                kafkaAdmin.inspect(stream, limit, method);
                             kafkaAdmin.close();
                             return messages;
                           } catch (JsonProcessingException ex) {

--- a/platform-api/src/main/java/io/datacater/core/stream/StreamsUtilities.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/StreamsUtilities.java
@@ -19,8 +19,7 @@ public class StreamsUtilities {
     return getStreamMessages(uuid, 100L, false);
   }
 
-  public Uni<List<StreamMessage>> getStreamMessages(
-      UUID uuid, Long limit, boolean distributed) {
+  public Uni<List<StreamMessage>> getStreamMessages(UUID uuid, Long limit, boolean distributed) {
     return dsf.withTransaction(
         ((session, transaction) ->
             session

--- a/platform-api/src/main/java/io/datacater/core/stream/StreamsUtilities.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/StreamsUtilities.java
@@ -20,7 +20,7 @@ public class StreamsUtilities {
   }
 
   public Uni<List<StreamMessage>> getStreamMessages(
-      UUID uuid, Long limit, boolean distributedInspect) {
+      UUID uuid, Long limit, boolean distributed) {
     return dsf.withTransaction(
         ((session, transaction) ->
             session
@@ -37,7 +37,7 @@ public class StreamsUtilities {
                             stream.spec().getKafka().put("max.poll.records", limit.intValue());
                             StreamService kafkaAdmin = KafkaStreamsAdmin.from(stream);
                             List<StreamMessage> messages =
-                                kafkaAdmin.inspect(stream, limit, distributedInspect);
+                                kafkaAdmin.inspect(stream, limit, distributed);
                             kafkaAdmin.close();
                             return messages;
                           } catch (JsonProcessingException ex) {

--- a/platform-api/src/main/java/io/datacater/core/stream/StreamsUtilities.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/StreamsUtilities.java
@@ -16,7 +16,6 @@ public class StreamsUtilities {
   @Inject DataCaterSessionFactory dsf;
 
   public Uni<List<StreamMessage>> getStreamMessages(UUID uuid) {
-    // TODO what static value would be better here, distributed or not?
     return getStreamMessages(uuid, 100L, false);
   }
 

--- a/platform-api/src/main/resources/application.yml
+++ b/platform-api/src/main/resources/application.yml
@@ -220,6 +220,9 @@ datacater:
         testStreamTopicOutLong:
           connector: smallrye-kafka
           topic: testLongDeserializer
+        testStreamInspectMethods:
+          connector: smallrye-kafka
+          topic: testStreamInspect
   smallrye:
     jwt:
       sign:

--- a/platform-api/src/test/java/io/datacater/core/stream/StreamInspectLongTest.java
+++ b/platform-api/src/test/java/io/datacater/core/stream/StreamInspectLongTest.java
@@ -52,7 +52,7 @@ class StreamInspectLongTest {
         given().pathParam("uuid", uuid.toString()).queryParam("limit", "3").get("/{uuid}/inspect");
 
     Assertions.assertEquals(200, response.getStatusCode());
-    Assertions.assertTrue(response.body().asString().contains("1000"));
+    Assertions.assertTrue(response.body().asString().contains("\"value\":\"test"));
   }
 
   void start() throws IOException {

--- a/platform-api/src/test/java/io/datacater/core/stream/StreamInspectMethodsTest.java
+++ b/platform-api/src/test/java/io/datacater/core/stream/StreamInspectMethodsTest.java
@@ -17,6 +17,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.inject.Inject;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
@@ -42,25 +43,33 @@ class StreamInspectMethodsTest {
     Response response =
         given().pathParam("uuid", uuid.toString()).queryParams("limit", "3").get("/{uuid}/inspect");
 
+    int countPart0 = StringUtils.countMatches(response.body().asString(), "\"partition\":0");
+    int countPart1 = StringUtils.countMatches(response.body().asString(), "\"partition\":1");
+    int countPart2 = StringUtils.countMatches(response.body().asString(), "\"partition\":2");
+
     Assertions.assertEquals(200, response.getStatusCode());
-    Assertions.assertTrue(response.body().asString().contains("\"partition\":0"));
-    Assertions.assertFalse(response.body().asString().contains("\"partition\":1"));
-    Assertions.assertFalse(response.body().asString().contains("\"partition\":2"));
+    Assertions.assertNotEquals(0, countPart0);
+    Assertions.assertEquals(0, countPart1);
+    Assertions.assertEquals(0, countPart2);
   }
 
   @Test
   @Order(2)
-  void testDistributedInspect() {
+  void testUniformInspect() {
     Response response =
         given()
             .pathParam("uuid", uuid.toString())
-            .queryParams("limit", "10", "sampleMethod", SampleMethod.UNIFORM)
+            .queryParams("limit", "15", "sampleMethod", SampleMethod.UNIFORM)
             .get("/{uuid}/inspect");
 
+    int countPart0 = StringUtils.countMatches(response.body().asString(), "\"partition\":0");
+    int countPart1 = StringUtils.countMatches(response.body().asString(), "\"partition\":1");
+    int countPart2 = StringUtils.countMatches(response.body().asString(), "\"partition\":2");
+
     Assertions.assertEquals(200, response.getStatusCode());
-    Assertions.assertTrue(response.body().asString().contains("\"partition\":0"));
-    Assertions.assertTrue(response.body().asString().contains("\"partition\":1"));
-    Assertions.assertTrue(response.body().asString().contains("\"partition\":2"));
+    Assertions.assertEquals(5, countPart0);
+    Assertions.assertEquals(5, countPart1);
+    Assertions.assertEquals(5, countPart2);
   }
 
   @Test
@@ -72,10 +81,14 @@ class StreamInspectMethodsTest {
             .queryParams("limit", "10", "sampleMethod", SampleMethod.SEQUENCED)
             .get("/{uuid}/inspect");
 
+    int countPart0 = StringUtils.countMatches(response.body().asString(), "\"partition\":0");
+    int countPart1 = StringUtils.countMatches(response.body().asString(), "\"partition\":1");
+    int countPart2 = StringUtils.countMatches(response.body().asString(), "\"partition\":2");
+
     Assertions.assertEquals(200, response.getStatusCode());
-    Assertions.assertTrue(response.body().asString().contains("\"partition\":0"));
-    Assertions.assertFalse(response.body().asString().contains("\"partition\":1"));
-    Assertions.assertFalse(response.body().asString().contains("\"partition\":2"));
+    Assertions.assertNotEquals(0, countPart0);
+    Assertions.assertEquals(0, countPart1);
+    Assertions.assertEquals(0, countPart2);
   }
 
   void start() throws IOException, ExecutionException, InterruptedException, TimeoutException {

--- a/platform-api/src/test/java/io/datacater/core/stream/StreamInspectMethodsTest.java
+++ b/platform-api/src/test/java/io/datacater/core/stream/StreamInspectMethodsTest.java
@@ -20,7 +20,6 @@ import javax.inject.Inject;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
-import org.jboss.logging.Logger;
 import org.junit.jupiter.api.*;
 
 @QuarkusTest
@@ -28,8 +27,6 @@ import org.junit.jupiter.api.*;
 @TestHTTPEndpoint(StreamEndpoint.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class StreamInspectMethodsTest {
-
-  private static final Logger LOGGER = Logger.getLogger(StreamInspectMethodsTest.class);
 
   @Inject
   @Channel("testStreamInspectMethods")
@@ -44,8 +41,6 @@ class StreamInspectMethodsTest {
     start();
     Response response =
         given().pathParam("uuid", uuid.toString()).queryParams("limit", "3").get("/{uuid}/inspect");
-
-    LOGGER.info(response.body().asString());
 
     Assertions.assertEquals(200, response.getStatusCode());
     Assertions.assertTrue(response.body().asString().contains("\"partition\":0"));
@@ -62,8 +57,6 @@ class StreamInspectMethodsTest {
             .queryParams("limit", "10", "distributedInspect", "true")
             .get("/{uuid}/inspect");
 
-    LOGGER.info(response.body().asString());
-
     Assertions.assertEquals(200, response.getStatusCode());
     Assertions.assertTrue(response.body().asString().contains("\"partition\":0"));
     Assertions.assertTrue(response.body().asString().contains("\"partition\":1"));
@@ -78,8 +71,6 @@ class StreamInspectMethodsTest {
             .pathParam("uuid", uuid.toString())
             .queryParams("limit", "10", "distributedInspect", "false")
             .get("/{uuid}/inspect");
-
-    LOGGER.info(response.body().asString());
 
     Assertions.assertEquals(200, response.getStatusCode());
     Assertions.assertTrue(response.body().asString().contains("\"partition\":0"));

--- a/platform-api/src/test/java/io/datacater/core/stream/StreamInspectMethodsTest.java
+++ b/platform-api/src/test/java/io/datacater/core/stream/StreamInspectMethodsTest.java
@@ -54,7 +54,7 @@ class StreamInspectMethodsTest {
     Response response =
         given()
             .pathParam("uuid", uuid.toString())
-            .queryParams("limit", "10", "distributedInspect", "true")
+            .queryParams("limit", "10", "distributed", "true")
             .get("/{uuid}/inspect");
 
     Assertions.assertEquals(200, response.getStatusCode());
@@ -69,7 +69,7 @@ class StreamInspectMethodsTest {
     Response response =
         given()
             .pathParam("uuid", uuid.toString())
-            .queryParams("limit", "10", "distributedInspect", "false")
+            .queryParams("limit", "10", "distributed", "false")
             .get("/{uuid}/inspect");
 
     Assertions.assertEquals(200, response.getStatusCode());

--- a/platform-api/src/test/java/io/datacater/core/stream/StreamInspectMethodsTest.java
+++ b/platform-api/src/test/java/io/datacater/core/stream/StreamInspectMethodsTest.java
@@ -54,7 +54,7 @@ class StreamInspectMethodsTest {
     Response response =
         given()
             .pathParam("uuid", uuid.toString())
-            .queryParams("limit", "10", "distributed", "true")
+            .queryParams("limit", "10", "sampleMethod", SampleMethod.UNIFORM)
             .get("/{uuid}/inspect");
 
     Assertions.assertEquals(200, response.getStatusCode());
@@ -65,11 +65,11 @@ class StreamInspectMethodsTest {
 
   @Test
   @Order(3)
-  void testTopDownInspect() {
+  void testSequencedInspect() {
     Response response =
         given()
             .pathParam("uuid", uuid.toString())
-            .queryParams("limit", "10", "distributed", "false")
+            .queryParams("limit", "10", "sampleMethod", SampleMethod.SEQUENCED)
             .get("/{uuid}/inspect");
 
     Assertions.assertEquals(200, response.getStatusCode());

--- a/platform-api/src/test/java/io/datacater/core/stream/StreamInspectMethodsTest.java
+++ b/platform-api/src/test/java/io/datacater/core/stream/StreamInspectMethodsTest.java
@@ -1,0 +1,119 @@
+package io.datacater.core.stream;
+
+import static io.restassured.RestAssured.given;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import java.io.IOException;
+import java.net.URL;
+import java.util.UUID;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import javax.inject.Inject;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.*;
+
+@QuarkusTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestHTTPEndpoint(StreamEndpoint.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class StreamInspectMethodsTest {
+
+  private static final Logger LOGGER = Logger.getLogger(StreamInspectMethodsTest.class);
+
+  @Inject
+  @Channel("testStreamInspectMethods")
+  Emitter<ProducerRecord<String, String>> producer;
+
+  UUID uuid;
+
+  @Test
+  @Order(1)
+  void testDefaultInspect()
+      throws IOException, ExecutionException, InterruptedException, TimeoutException {
+    start();
+    Response response =
+        given().pathParam("uuid", uuid.toString()).queryParams("limit", "3").get("/{uuid}/inspect");
+
+    LOGGER.info(response.body().asString());
+
+    Assertions.assertEquals(200, response.getStatusCode());
+    Assertions.assertTrue(response.body().asString().contains("\"partition\":0"));
+    Assertions.assertFalse(response.body().asString().contains("\"partition\":1"));
+    Assertions.assertFalse(response.body().asString().contains("\"partition\":2"));
+  }
+
+  @Test
+  @Order(2)
+  void testDistributedInspect() {
+    Response response =
+        given()
+            .pathParam("uuid", uuid.toString())
+            .queryParams("limit", "10", "distributedInspect", "true")
+            .get("/{uuid}/inspect");
+
+    LOGGER.info(response.body().asString());
+
+    Assertions.assertEquals(200, response.getStatusCode());
+    Assertions.assertTrue(response.body().asString().contains("\"partition\":0"));
+    Assertions.assertTrue(response.body().asString().contains("\"partition\":1"));
+    Assertions.assertTrue(response.body().asString().contains("\"partition\":2"));
+  }
+
+  @Test
+  @Order(3)
+  void testTopDownInspect() {
+    Response response =
+        given()
+            .pathParam("uuid", uuid.toString())
+            .queryParams("limit", "10", "distributedInspect", "false")
+            .get("/{uuid}/inspect");
+
+    LOGGER.info(response.body().asString());
+
+    Assertions.assertEquals(200, response.getStatusCode());
+    Assertions.assertTrue(response.body().asString().contains("\"partition\":0"));
+    Assertions.assertFalse(response.body().asString().contains("\"partition\":1"));
+    Assertions.assertFalse(response.body().asString().contains("\"partition\":2"));
+  }
+
+  void start() throws IOException, ExecutionException, InterruptedException, TimeoutException {
+    URL streamJsonURL =
+        ClassLoader.getSystemClassLoader()
+            .getResource("streamTestFiles/stream-test-inspect-methods.json");
+    ObjectMapper mapper = new JsonMapper();
+    JsonNode streamJson = mapper.readTree(streamJsonURL);
+    RequestSpecification request = given();
+    String json = streamJson.toString();
+    request.header("Content-Type", "application/json");
+    request.body(json);
+
+    Response response = request.post();
+    StreamEntity se = mapper.readValue(response.body().asString(), StreamEntity.class);
+    uuid = se.getId();
+
+    for (int i = 0; i <= 300; i++) {
+      producer.send(
+          new ProducerRecord<>(
+              "testStreamInspect", String.format("test %d", i), String.format("test %d", i)));
+    }
+    CompletionStage<Void> lastMessageToWaitOn =
+        producer.send(
+            new ProducerRecord<>(
+                "testStreamInspect",
+                String.format("test %d", 1000),
+                String.format("test %d", 2000)));
+
+    lastMessageToWaitOn.toCompletableFuture().get(1000, TimeUnit.MILLISECONDS);
+  }
+}

--- a/platform-api/src/test/java/io/datacater/core/stream/StreamInspectStringTest.java
+++ b/platform-api/src/test/java/io/datacater/core/stream/StreamInspectStringTest.java
@@ -57,7 +57,7 @@ class StreamInspectStringTest {
     Response response =
         given()
             .pathParam("uuid", uuid.toString())
-            .queryParams("limit", "3", "distributed", "true")
+            .queryParams("limit", "3", "sampleMethod", SampleMethod.UNIFORM)
             .get("/{uuid}/inspect");
 
     Assertions.assertEquals(200, response.getStatusCode());

--- a/platform-api/src/test/java/io/datacater/core/stream/StreamInspectStringTest.java
+++ b/platform-api/src/test/java/io/datacater/core/stream/StreamInspectStringTest.java
@@ -20,6 +20,7 @@ import javax.inject.Inject;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -28,6 +29,8 @@ import org.junit.jupiter.api.TestInstance;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestHTTPEndpoint(StreamEndpoint.class)
 class StreamInspectStringTest {
+
+  private static final Logger LOGGER = Logger.getLogger(StreamInspectStringTest.class);
 
   @Inject
   @Channel("testStreamTopicOutString")
@@ -55,7 +58,12 @@ class StreamInspectStringTest {
     lastMessageToWaitOn.toCompletableFuture().get(1000, TimeUnit.MILLISECONDS);
 
     Response response =
-        given().pathParam("uuid", uuid.toString()).queryParam("limit", "3").get("/{uuid}/inspect");
+        given()
+            .pathParam("uuid", uuid.toString())
+            .queryParams("limit", "3", "distributedInspect", "true")
+            .get("/{uuid}/inspect");
+
+    LOGGER.info(response.body().asString());
 
     Assertions.assertEquals(200, response.getStatusCode());
     Assertions.assertTrue(response.body().asString().contains("test 1000"));

--- a/platform-api/src/test/java/io/datacater/core/stream/StreamInspectStringTest.java
+++ b/platform-api/src/test/java/io/datacater/core/stream/StreamInspectStringTest.java
@@ -61,7 +61,7 @@ class StreamInspectStringTest {
             .get("/{uuid}/inspect");
 
     Assertions.assertEquals(200, response.getStatusCode());
-    Assertions.assertTrue(response.body().asString().contains("test 1000"));
+    Assertions.assertTrue(response.body().asString().contains("\"value\":\"test"));
   }
 
   void start() throws IOException {

--- a/platform-api/src/test/java/io/datacater/core/stream/StreamInspectStringTest.java
+++ b/platform-api/src/test/java/io/datacater/core/stream/StreamInspectStringTest.java
@@ -20,7 +20,6 @@ import javax.inject.Inject;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
-import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -29,8 +28,6 @@ import org.junit.jupiter.api.TestInstance;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestHTTPEndpoint(StreamEndpoint.class)
 class StreamInspectStringTest {
-
-  private static final Logger LOGGER = Logger.getLogger(StreamInspectStringTest.class);
 
   @Inject
   @Channel("testStreamTopicOutString")
@@ -62,8 +59,6 @@ class StreamInspectStringTest {
             .pathParam("uuid", uuid.toString())
             .queryParams("limit", "3", "distributedInspect", "true")
             .get("/{uuid}/inspect");
-
-    LOGGER.info(response.body().asString());
 
     Assertions.assertEquals(200, response.getStatusCode());
     Assertions.assertTrue(response.body().asString().contains("test 1000"));

--- a/platform-api/src/test/java/io/datacater/core/stream/StreamInspectStringTest.java
+++ b/platform-api/src/test/java/io/datacater/core/stream/StreamInspectStringTest.java
@@ -57,7 +57,7 @@ class StreamInspectStringTest {
     Response response =
         given()
             .pathParam("uuid", uuid.toString())
-            .queryParams("limit", "3", "distributedInspect", "true")
+            .queryParams("limit", "3", "distributed", "true")
             .get("/{uuid}/inspect");
 
     Assertions.assertEquals(200, response.getStatusCode());

--- a/platform-api/src/test/resources/streamTestFiles/stream-test-inspect-methods.json
+++ b/platform-api/src/test/resources/streamTestFiles/stream-test-inspect-methods.json
@@ -1,0 +1,15 @@
+{
+  "name": "testStreamInspect",
+  "spec": {
+    "kafka": {
+      "bootstrap.servers": "localhost:9092",
+      "key.deserializer": "org.apache.kafka.common.serialization.StringDeserializer",
+      "value.deserializer": "org.apache.kafka.common.serialization.StringDeserializer",
+      "topic": {
+        "config": {
+        }
+      }
+    },
+    "kind": "KAFKA"
+  }
+}


### PR DESCRIPTION
This PR adds a new method to retrieve messages from partitions:
The new method will first get messages from partition1, if the expected amount is not yet reached, the amount is filled with messages from aprtition 2 and so on