### PR TITLE
feat(platform-api): Disable CORS by default

### DIFF
--- a/platform-api/src/main/resources/application.yml
+++ b/platform-api/src/main/resources/application.yml
@@ -27,7 +27,7 @@ quarkus  :
   http:
     root-path: /api/${datacater.api.version}
     non-application-root-path: /q
-    cors: true
+    cors: false
     auth:
       basic: true
       proactive: true


### PR DESCRIPTION
We recently migrated from Quarkus 2.12 to Quarkus 2.16. [From 2.15 on](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.15#cors-filter-returns-http-403-for-failed-preflight-requests), Quarkus started returning the HTTP response status `403` if the CORS preflight request failed. As a consequence, our authentication fails if the CORS domains are not correctly configured.

Since our open core is not addressing production use cases, we now start with disabling CORS by default to allow developers exploring DataCater without having to configure CORS domains.

Users can re-enable CORS by setting the environment variable `QUARKUS_HTTP_CORS` of the `datacater` pod(s) to `true`.