### PR TITLE
feat(ui): Update npm

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -12315,9 +12315,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "8.19.2",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-8.19.2.tgz",
-      "integrity": "sha512-MWkISVv5f7iZbfNkry5/5YBqSYJEDAKSJdL+uzSQuyLg+hgLQUyZynu3SH6bOZlvR9ZvJYk2EiJO6B1r+ynwHg==",
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-8.19.4.tgz",
+      "integrity": "sha512-3HANl8i9DKnUA89P4KEgVNN28EjSeDCmvEqbzOAuxCFDzdBZzjUl99zgnGpOUumvW5lvJo2HKcjrsc+tfyv1Hw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -12326,7 +12326,6 @@
         "@npmcli/fs",
         "@npmcli/map-workspaces",
         "@npmcli/package-json",
-        "@npmcli/promise-spawn",
         "@npmcli/run-script",
         "abbrev",
         "archy",
@@ -12396,13 +12395,12 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^5.6.2",
+        "@npmcli/arborist": "^5.6.3",
         "@npmcli/ci-detect": "^2.0.0",
         "@npmcli/config": "^4.2.1",
         "@npmcli/fs": "^2.1.0",
         "@npmcli/map-workspaces": "^2.0.3",
         "@npmcli/package-json": "^2.0.0",
-        "@npmcli/promise-spawn": "*",
         "@npmcli/run-script": "^4.2.1",
         "abbrev": "~1.1.1",
         "archy": "~1.0.0",
@@ -12413,18 +12411,18 @@
         "cli-table3": "^0.6.2",
         "columnify": "^1.6.0",
         "fastest-levenshtein": "^1.0.12",
-        "fs-minipass": "*",
+        "fs-minipass": "^2.1.0",
         "glob": "^8.0.1",
         "graceful-fs": "^4.2.10",
-        "hosted-git-info": "^5.1.0",
+        "hosted-git-info": "^5.2.1",
         "ini": "^3.0.1",
         "init-package-json": "^3.0.2",
         "is-cidr": "^4.0.2",
         "json-parse-even-better-errors": "^2.3.1",
         "libnpmaccess": "^6.0.4",
         "libnpmdiff": "^4.0.5",
-        "libnpmexec": "^4.0.13",
-        "libnpmfund": "^3.0.4",
+        "libnpmexec": "^4.0.14",
+        "libnpmfund": "^3.0.5",
         "libnpmhook": "^8.0.4",
         "libnpmorg": "^4.0.4",
         "libnpmpack": "^4.1.3",
@@ -12433,7 +12431,7 @@
         "libnpmteam": "^4.0.4",
         "libnpmversion": "^3.0.7",
         "make-fetch-happen": "^10.2.0",
-        "minimatch": "*",
+        "minimatch": "^5.1.0",
         "minipass": "^3.1.6",
         "minipass-pipeline": "^1.2.4",
         "mkdirp": "^1.0.4",
@@ -12475,7 +12473,7 @@
         "npx": "bin/npx-cli.js"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -12509,7 +12507,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "5.6.2",
+      "version": "5.6.3",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -12526,6 +12524,7 @@
         "bin-links": "^3.0.3",
         "cacache": "^16.1.3",
         "common-ancestor-path": "^1.0.1",
+        "hosted-git-info": "^5.2.1",
         "json-parse-even-better-errors": "^2.3.1",
         "json-stringify-nice": "^1.1.4",
         "minimatch": "^5.1.0",
@@ -13265,7 +13264,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "5.1.0",
+      "version": "5.2.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13276,7 +13275,7 @@
       }
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
-      "version": "4.1.0",
+      "version": "4.1.1",
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
@@ -13513,11 +13512,11 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "4.0.13",
+      "version": "4.0.14",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^5.6.2",
+        "@npmcli/arborist": "^5.6.3",
         "@npmcli/ci-detect": "^2.0.0",
         "@npmcli/fs": "^2.1.1",
         "@npmcli/run-script": "^4.2.0",
@@ -13537,11 +13536,11 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "3.0.4",
+      "version": "3.0.5",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^5.6.2"
+        "@npmcli/arborist": "^5.6.3"
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -29808,18 +29807,17 @@
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
     },
     "npm": {
-      "version": "8.19.2",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-8.19.2.tgz",
-      "integrity": "sha512-MWkISVv5f7iZbfNkry5/5YBqSYJEDAKSJdL+uzSQuyLg+hgLQUyZynu3SH6bOZlvR9ZvJYk2EiJO6B1r+ynwHg==",
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-8.19.4.tgz",
+      "integrity": "sha512-3HANl8i9DKnUA89P4KEgVNN28EjSeDCmvEqbzOAuxCFDzdBZzjUl99zgnGpOUumvW5lvJo2HKcjrsc+tfyv1Hw==",
       "requires": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^5.6.2",
+        "@npmcli/arborist": "^5.6.3",
         "@npmcli/ci-detect": "^2.0.0",
         "@npmcli/config": "^4.2.1",
         "@npmcli/fs": "^2.1.0",
         "@npmcli/map-workspaces": "^2.0.3",
         "@npmcli/package-json": "^2.0.0",
-        "@npmcli/promise-spawn": "*",
         "@npmcli/run-script": "^4.2.1",
         "abbrev": "~1.1.1",
         "archy": "~1.0.0",
@@ -29830,18 +29828,18 @@
         "cli-table3": "^0.6.2",
         "columnify": "^1.6.0",
         "fastest-levenshtein": "^1.0.12",
-        "fs-minipass": "*",
+        "fs-minipass": "^2.1.0",
         "glob": "^8.0.1",
         "graceful-fs": "^4.2.10",
-        "hosted-git-info": "^5.1.0",
+        "hosted-git-info": "^5.2.1",
         "ini": "^3.0.1",
         "init-package-json": "^3.0.2",
         "is-cidr": "^4.0.2",
         "json-parse-even-better-errors": "^2.3.1",
         "libnpmaccess": "^6.0.4",
         "libnpmdiff": "^4.0.5",
-        "libnpmexec": "^4.0.13",
-        "libnpmfund": "^3.0.4",
+        "libnpmexec": "^4.0.14",
+        "libnpmfund": "^3.0.5",
         "libnpmhook": "^8.0.4",
         "libnpmorg": "^4.0.4",
         "libnpmpack": "^4.1.3",
@@ -29850,7 +29848,7 @@
         "libnpmteam": "^4.0.4",
         "libnpmversion": "^3.0.7",
         "make-fetch-happen": "^10.2.0",
-        "minimatch": "*",
+        "minimatch": "^5.1.0",
         "minipass": "^3.1.6",
         "minipass-pipeline": "^1.2.4",
         "mkdirp": "^1.0.4",
@@ -29902,7 +29900,7 @@
           "bundled": true
         },
         "@npmcli/arborist": {
-          "version": "5.6.2",
+          "version": "5.6.3",
           "bundled": true,
           "requires": {
             "@isaacs/string-locale-compare": "^1.1.0",
@@ -29918,6 +29916,7 @@
             "bin-links": "^3.0.3",
             "cacache": "^16.1.3",
             "common-ancestor-path": "^1.0.1",
+            "hosted-git-info": "^5.2.1",
             "json-parse-even-better-errors": "^2.3.1",
             "json-stringify-nice": "^1.1.4",
             "minimatch": "^5.1.0",
@@ -30422,14 +30421,14 @@
           "bundled": true
         },
         "hosted-git-info": {
-          "version": "5.1.0",
+          "version": "5.2.1",
           "bundled": true,
           "requires": {
             "lru-cache": "^7.5.1"
           }
         },
         "http-cache-semantics": {
-          "version": "4.1.0",
+          "version": "4.1.1",
           "bundled": true
         },
         "http-proxy-agent": {
@@ -30591,10 +30590,10 @@
           }
         },
         "libnpmexec": {
-          "version": "4.0.13",
+          "version": "4.0.14",
           "bundled": true,
           "requires": {
-            "@npmcli/arborist": "^5.6.2",
+            "@npmcli/arborist": "^5.6.3",
             "@npmcli/ci-detect": "^2.0.0",
             "@npmcli/fs": "^2.1.1",
             "@npmcli/run-script": "^4.2.0",
@@ -30611,10 +30610,10 @@
           }
         },
         "libnpmfund": {
-          "version": "3.0.4",
+          "version": "3.0.5",
           "bundled": true,
           "requires": {
-            "@npmcli/arborist": "^5.6.2"
+            "@npmcli/arborist": "^5.6.3"
           }
         },
         "libnpmhook": {


### PR DESCRIPTION
Update the dependency `npm` to the latest patch release. This updates its indirect dependency `http-cache-semantics` and fixes a [vulnerability detected by dependabot](https://github.com/DataCater/datacater/security/dependabot/12).