### PR TITLE
feat(README): Reflect new service in port-forward

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ kubectl apply -f k8s-manifests/minikube-with-postgres-ns-default.yaml
 ```
 kubectl get all --all-namespaces
 ```
-4. Port-forward to service
+4. Port-forward to service `datacater-ui`
 ```
-kubectl port-forward ui 8080:8080
+kubectl port-forward svc/datacater-ui 8080:80
 ```
 5. Browse to `localhost:8080` in your browser. The default login credentials are `admin:admin`.
 


### PR DESCRIPTION
We recently changed our Helm Chart and switched from deploying our UI as a Pod to running it as a Deployment.
We added the service `datacater-ui`, which exposes the port `80` and allows to address the deployment of the UI.

This commits updates our readme accordingly.