### PR TITLE
fix: load image bash postgres config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ python-runner/transforms/
 # python
 __pycache__
 .venv
+/k8s-manifests/minikube-with-postgres-image-test.yaml

--- a/load-image-k8s.bash
+++ b/load-image-k8s.bash
@@ -22,7 +22,11 @@ minikube image load datacater/$NAME:$VERSION
 
 echo "Loaded image datacater/$NAME:$VERSION"
 
- helm template ./helm-charts/datacater\
+ helm template ./helm-charts/datacater -ndefault \
+   --skip-tests \
+   --set "postgres.enabled=true" \
+   --set "datacater.database.username=postgres" \
+   --set "postgres.username=postgres" \
    --set image.tag=$VERSION\
    --set image.repository=datacater/$NAME --skip-tests\
     > k8s-manifests/minikube-with-postgres-ns-default.yaml

--- a/load-image-k8s.bash
+++ b/load-image-k8s.bash
@@ -29,6 +29,7 @@ echo "Loaded image datacater/$NAME:$VERSION"
    --set "postgres.username=postgres" \
    --set image.tag=$VERSION\
    --set image.repository=datacater/$NAME --skip-tests\
-    > k8s-manifests/minikube-with-postgres-ns-default.yaml
+    > k8s-manifests/minikube-with-postgres-image-test.yaml
 
-echo "Updated helm template."
+echo "Created helm template."
+echo "to install, run the following command: kubectl apply -f k8s-manifests/minikube-with-postgres-image-test.yaml"


### PR DESCRIPTION
The current `load-image-k8s.bash` updates the `k8s-manifests/minikube-with-postgres-ns-default.yaml` but actually overwrites/removes the postgres `statefulset` and `service`, which causes the application to crash.

This PR configures postgres when the helm template command is called.