### PR TITLE
fix(ui/streams): Align default topic config

### DIFF
--- a/ui/src/containers/streams/EditStream.js
+++ b/ui/src/containers/streams/EditStream.js
@@ -275,7 +275,7 @@ class EditStream extends Component {
                         data-prefix="spec.kafka.topic"
                         name="num.partitions"
                         onChange={this.handleChange}
-                        placeholder="1"
+                        placeholder="3"
                         value={
                           this.state.stream.spec.kafka["topic"][
                             "num.partitions"
@@ -303,7 +303,7 @@ class EditStream extends Component {
                         data-prefix="spec.kafka.topic"
                         name="replication.factor"
                         onChange={this.handleChange}
-                        placeholder="3"
+                        placeholder="1"
                         value={
                           this.state.stream.spec.kafka["topic"][
                             "replication.factor"

--- a/ui/src/containers/streams/NewStream.js
+++ b/ui/src/containers/streams/NewStream.js
@@ -257,7 +257,7 @@ class NewStream extends Component {
                         data-prefix="spec.kafka.topic"
                         name="num.partitions"
                         onChange={this.handleChange}
-                        placeholder="1"
+                        placeholder="3"
                         value={
                           this.state.stream.spec.kafka["topic"][
                             "num.partitions"
@@ -279,7 +279,7 @@ class NewStream extends Component {
                         data-prefix="spec.kafka.topic"
                         name="replication.factor"
                         onChange={this.handleChange}
-                        placeholder="3"
+                        placeholder="1"
                         value={
                           this.state.stream.spec.kafka["topic"][
                             "replication.factor"


### PR DESCRIPTION
Our control plane uses the following default values when creating Apache Kafka topics:
- num.partitions = 3
- replication.factor = 1

This commit aligns the default values displayed in the frontend with the ones that are actually used in the control plane.