### PR TITLE
fix(streams): Avoid merging config into streams when updating streams

### DIFF
--- a/platform-api/src/test/java/io/datacater/core/config/ConfigStreamTest.java
+++ b/platform-api/src/test/java/io/datacater/core/config/ConfigStreamTest.java
@@ -2,12 +2,17 @@ package io.datacater.core.config;
 
 import static io.restassured.RestAssured.given;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import io.datacater.core.stream.StreamEntity;
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
 import java.io.IOException;
 import java.net.URL;
+import java.util.UUID;
 import org.junit.jupiter.api.*;
 
 @QuarkusTest
@@ -16,6 +21,8 @@ import org.junit.jupiter.api.*;
 class ConfigStreamTest {
   JsonNode configJson;
   JsonNode streamJson;
+  JsonNode streamJsonForUpdate;
+  UUID streamId;
   final String baseURI = "http://localhost:8081";
   final String streamsPath = "/streams";
   final String configsPath = "/configs";
@@ -29,9 +36,13 @@ class ConfigStreamTest {
             .getResource("configTestFiles/streams/stream-config-test.json");
     URL streamURL =
         ClassLoader.getSystemClassLoader().getResource("configTestFiles/streams/stream-test.json");
+    URL streamUpdateURL =
+        ClassLoader.getSystemClassLoader()
+            .getResource("configTestFiles/streams/stream-test-update.json");
 
     configJson = mapper.readTree(configURL);
     streamJson = mapper.readTree(streamURL);
+    streamJsonForUpdate = mapper.readTree(streamUpdateURL);
   }
 
   @Test
@@ -49,14 +60,36 @@ class ConfigStreamTest {
 
   @Test
   @Order(2)
-  void postStream() {
+  void postStream() throws JsonProcessingException {
 
-    given()
-        .header("Content-Type", "application/json")
-        .body(streamJson.toString())
-        .baseUri(baseURI)
-        .post(streamsPath)
-        .then()
-        .statusCode(200);
+    RequestSpecification request = given();
+    request.baseUri(baseURI);
+    request.header("Content-Type", "application/json");
+    request.body(streamJson.toString());
+    Response response = request.post(streamsPath);
+
+    ObjectMapper mapper = new JsonMapper();
+    StreamEntity se = mapper.readValue(response.body().asString(), StreamEntity.class);
+    streamId = se.getId();
+    Assertions.assertEquals(200, response.getStatusCode());
+  }
+
+  @Test
+  @Order(3)
+  void updateStreamWithConfig() throws JsonProcessingException {
+    ObjectMapper objectMapper = new ObjectMapper();
+    String streamPath = String.format("%s/%s", streamsPath, streamId.toString());
+
+    Response response =
+        given()
+            .header("Content-Type", "application/json")
+            .body(streamJsonForUpdate.toString())
+            .put(streamPath);
+
+    ObjectMapper mapper = new JsonMapper();
+    StreamEntity se = mapper.readValue(response.body().asString(), StreamEntity.class);
+
+    // Properties from the config should not be merged into stream object when updating
+    Assertions.assertEquals("", se.getSpec().findValue("bootstrap.servers").asText());
   }
 }

--- a/platform-api/src/test/resources/configTestFiles/streams/stream-test-update.json
+++ b/platform-api/src/test/resources/configTestFiles/streams/stream-test-update.json
@@ -1,0 +1,17 @@
+{
+  "name": "stream-test",
+  "spec": {
+    "kafka": {
+      "bootstrap.servers": "",
+      "topic": {
+        "config": {
+        }
+      }
+    },
+    "kind": "KAFKA"
+  },
+  "configSelector": {
+    "app.datacater.io/name": "stream-config",
+    "label": "does-not-exist"
+  }
+}


### PR DESCRIPTION
When updating a stream object using the endpoint `PUT /streams/:uuid`, we should not merge referenced config objects into the stream object before persisting it.