### PR TITLE
feat(ui/deployments): Allow selecting a deployment replica

### DIFF
--- a/ui/src/actions/deployments.js
+++ b/ui/src/actions/deployments.js
@@ -166,7 +166,7 @@ export function deleteDeployment(id) {
   };
 }
 
-export function fetchDeploymentLogs(id) {
+export function fetchDeploymentLogs(id, replica = 1) {
   const requestDeploymentLogs = () => ({
     type: "REQUEST_LOGS_DEPLOYMENT",
   });
@@ -184,7 +184,7 @@ export function fetchDeploymentLogs(id) {
   return function (dispatch) {
     dispatch(requestDeploymentLogs());
 
-    return callApi(`/deployments/${id}/logs`).then(
+    return callApi(`/deployments/${id}/logs?replica=${replica}`).then(
       (response) => dispatch(receivedDeploymentLogs(response.data)),
       (error) => {
         if (error.response.status === 401) {
@@ -202,7 +202,7 @@ export function fetchDeploymentLogs(id) {
   };
 }
 
-export function fetchDeploymentHealth(id) {
+export function fetchDeploymentHealth(id, replica = 1) {
   const requestDeploymentHealth = () => ({
     type: "REQUEST_HEALTH_DEPLOYMENT",
   });
@@ -220,7 +220,7 @@ export function fetchDeploymentHealth(id) {
   return function (dispatch) {
     dispatch(requestDeploymentHealth());
 
-    return callApi(`/deployments/${id}/health`).then(
+    return callApi(`/deployments/${id}/health?replica=${replica}`).then(
       (response) => dispatch(receivedDeploymentHealth(response.data)),
       (error) => {
         if (error.response.status === 401) {
@@ -244,7 +244,7 @@ export function resetDeploymentHealth() {
   };
 }
 
-export function fetchDeploymentMetrics(id) {
+export function fetchDeploymentMetrics(id, replica = 1) {
   const requestDeploymentMetrics = () => ({
     type: "REQUEST_METRICS_DEPLOYMENT",
   });
@@ -262,7 +262,7 @@ export function fetchDeploymentMetrics(id) {
   return function (dispatch) {
     dispatch(requestDeploymentMetrics());
 
-    return callApi(`/deployments/${id}/metrics`).then(
+    return callApi(`/deployments/${id}/metrics?replica=${replica}`).then(
       (response) => dispatch(receivedDeploymentMetrics(response.data)),
       (error) => {
         if (error.response.status === 401) {

--- a/ui/src/components/deployments/ReplicaSelect.js
+++ b/ui/src/components/deployments/ReplicaSelect.js
@@ -10,7 +10,11 @@ class ReplicaSelect extends Component {
       deployment.spec === undefined ||
       deployment.spec.replicas < 1
     ) {
-      return <></>;
+      return (
+        <button className="btn btn-light ms-2" disabled={true}>
+          No replicas available
+        </button>
+      );
     }
 
     const replicas =

--- a/ui/src/components/deployments/ReplicaSelect.js
+++ b/ui/src/components/deployments/ReplicaSelect.js
@@ -1,0 +1,53 @@
+import React, { Component } from "react";
+import Select from "react-select";
+
+class ReplicaSelect extends Component {
+  render() {
+    const { currentReplica, deployment, updateCurrentReplicaFunc } = this.props;
+
+    if (
+      deployment === undefined ||
+      deployment.spec === undefined ||
+      deployment.spec.replicas < 1
+    ) {
+      return <></>;
+    }
+
+    const replicas =
+      deployment.spec === undefined || isNaN(parseInt(deployment.spec.replicas))
+        ? 1 // By default, deployments have 1 replica
+        : parseInt(deployment.spec.replicas);
+
+    const replicaOptions = [];
+    for (let i = 0; i < replicas; i++) {
+      const replica = i + 1;
+      replicaOptions.push({
+        label: `Replica ${replica}`,
+        value: replica,
+      });
+    }
+
+    return (
+      <div className="float-end ms-2">
+        <Select
+          isSearchable
+          defaultValue={
+            replicaOptions.filter(
+              (option) => option.value === currentReplica
+            )[0]
+          }
+          options={replicaOptions}
+          onChange={(value) => updateCurrentReplicaFunc(value.value)}
+          styles={{
+            control: (baseStyles, state) => ({
+              ...baseStyles,
+              borderRadius: "0.375rem",
+            }),
+          }}
+        />
+      </div>
+    );
+  }
+}
+
+export default ReplicaSelect;

--- a/ui/src/containers/deployments/DeploymentLogs.js
+++ b/ui/src/containers/deployments/DeploymentLogs.js
@@ -3,6 +3,7 @@ import { connect } from "react-redux";
 import { Redirect } from "react-router-dom";
 import Breadcrumb from "../../components/layout/Breadcrumb";
 import Header from "../../components/layout/Header";
+import ReplicaSelect from "../../components/deployments/ReplicaSelect";
 import {
   fetchDeployment,
   fetchDeploymentLogs,
@@ -12,6 +13,7 @@ class DeploymentLogs extends Component {
   constructor(props) {
     super(props);
     this.state = {
+      currentReplica: 1,
       followLogs: false,
       logMessages: [],
       wrapLines: false,
@@ -19,6 +21,7 @@ class DeploymentLogs extends Component {
     this.fetchLogs = this.fetchLogs.bind(this);
     this.toggleFollowLogs = this.toggleFollowLogs.bind(this);
     this.toggleWrapLines = this.toggleWrapLines.bind(this);
+    this.updateCurrentReplica = this.updateCurrentReplica.bind(this);
   }
 
   componentDidMount() {
@@ -38,12 +41,15 @@ class DeploymentLogs extends Component {
     });
   }
 
-  fetchLogs() {
-    this.props.fetchDeploymentLogs(this.getDeploymentId()).then(() => {
-      this.setState({
-        logMessages: this.props.deployments.logMessages,
+  fetchLogs(replica = undefined) {
+    const currentReplica = replica || this.state.currentReplica;
+    this.props
+      .fetchDeploymentLogs(this.getDeploymentId(), currentReplica)
+      .then(() => {
+        this.setState({
+          logMessages: this.props.deployments.logMessages,
+        });
       });
-    });
   }
 
   toggleFollowLogs(event) {
@@ -70,6 +76,13 @@ class DeploymentLogs extends Component {
     this.setState({
       wrapLines: !this.state.wrapLines,
     });
+  }
+
+  updateCurrentReplica(replica) {
+    this.setState({
+      currentReplica: replica,
+    });
+    this.fetchLogs(replica);
   }
 
   getDeploymentId() {
@@ -117,7 +130,14 @@ class DeploymentLogs extends Component {
           />
           <Header
             apiDocs="https://docs.datacater.io/docs/api/deployments/"
-            apiPath={`/deployments/${deployment.uuid}/logs`}
+            apiPath={`/deployments/${deployment.uuid}/logs?replica=${this.state.currentReplica}`}
+            buttons={
+              <ReplicaSelect
+                currentReplica={this.state.currentReplica}
+                deployment={deployment}
+                updateCurrentReplicaFunc={this.updateCurrentReplica}
+              />
+            }
             title={deployment.name || "Untitled deployment"}
           />
         </div>


### PR DESCRIPTION
We support running deployments with multiple replicas.

This commit adds support for selecting a specific replica when viewing a deployment.

The UI shows the health/metrics/logs of the selected replica.

By default, replica 1 is selected.

## Impact on existing behavior

This PR does not break any existing behavior. At the moment, the UI does not specify the replica when calling the backend, thus it always shows information from the [default replica](https://github.com/DataCater/datacater/blob/main/platform-api/src/main/java/io/datacater/core/deployment/DeploymentEndpoint.java#L69) 1.

## How it looks in action

Choosing a replica when viewing a deployment:
<img width="1624" alt="Screenshot 2023-03-31 at 10 27 12" src="https://user-images.githubusercontent.com/128683/229067651-d30932ca-03ce-4cc3-8d52-9be7ae063e41.png">

Choosing a replica when viewing the logs of a deployment:
<img width="1624" alt="Screenshot 2023-03-31 at 10 27 36" src="https://user-images.githubusercontent.com/128683/229067644-b0f2ec8c-1cf6-4a6c-b842-eb04a65da87e.png">