### PR TITLE
build: update Quarkus to most recent version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 #Gradle properties
-quarkusPluginVersion=2.16.2.Final
+quarkusPluginVersion=2.16.6.Final
 quarkusPlatformArtifactId=quarkus-bom
 quarkusPluginId=io.quarkus
 quarkusPlatformGroupId=io.quarkus.platform
-quarkusPlatformVersion=2.16.2.Final
+quarkusPlatformVersion=2.16.6.Final
 org.gradle.jvmargs=-Xmx1024m


### PR DESCRIPTION
This PR is to upgrade quarkus to the most recent version. Ticket #177 needs at least quarkus 2.16.5.FINAL