### PR TITLE
fix: class to classNames

### DIFF
--- a/ui/src/components/configs/Tabs.js
+++ b/ui/src/components/configs/Tabs.js
@@ -5,12 +5,12 @@ class Tabs extends Component {
     const { currentTab, updateTabFunc } = this.props;
 
     return (
-      <ul class="nav flex-column nav-pills mt-4">
+      <ul className="nav flex-column nav-pills mt-4">
         {currentTab === "config" && (
           <>
-            <li class="nav-item">
+            <li className="nav-item">
               <a
-                class="nav-link active"
+                className="nav-link active"
                 href="#"
                 data-tab="config"
                 onClick={updateTabFunc}
@@ -18,9 +18,9 @@ class Tabs extends Component {
                 Config
               </a>
             </li>
-            <li class="nav-item mt-2">
+            <li className="nav-item mt-2">
               <a
-                class="nav-link"
+                className="nav-link"
                 href="#"
                 data-tab="spec"
                 onClick={updateTabFunc}
@@ -32,9 +32,9 @@ class Tabs extends Component {
         )}
         {currentTab === "spec" && (
           <>
-            <li class="nav-item">
+            <li className="nav-item">
               <a
-                class="nav-link"
+                className="nav-link"
                 href="#"
                 data-tab="config"
                 onClick={updateTabFunc}
@@ -42,9 +42,9 @@ class Tabs extends Component {
                 Config
               </a>
             </li>
-            <li class="nav-item mt-2">
+            <li className="nav-item mt-2">
               <a
-                class="nav-link active"
+                className="nav-link active"
                 href="#"
                 data-tab="spec"
                 onClick={updateTabFunc}

--- a/ui/src/containers/configs/EditConfig.js
+++ b/ui/src/containers/configs/EditConfig.js
@@ -425,7 +425,7 @@ class EditConfig extends Component {
                       />
                     </div>
                   ))}
-                <div class="col-12 mt-3">
+                <div className="col-12 mt-3">
                   <h6 className="d-inline me-2">Add label</h6>
                 </div>
                 <div className="col-12 mt-1">

--- a/ui/src/containers/configs/NewConfig.js
+++ b/ui/src/containers/configs/NewConfig.js
@@ -513,8 +513,8 @@ class NewConfig extends Component {
                       />
                     </div>
                   ))}
-                <div class="col-12 mt-3">
-                  <h6 class="d-inline me-2">Add label</h6>
+                <div className="col-12 mt-3">
+                  <h6 className="d-inline me-2">Add label</h6>
                 </div>
                 <div className="col-12 mt-1">
                   <div className="row">


### PR DESCRIPTION
A couple of places used `class` instead `className` for react components or html tags. This fixes visible bugs from the console.


<img width="2549" alt="Screenshot 2023-04-24 at 15 50 15" src="https://user-images.githubusercontent.com/4265969/234037535-ae004f97-799a-4521-977d-e139962c91bb.png">
