### PR TITLE
fix: change timeout in tests

### DIFF
--- a/platform-api/src/test/java/io/datacater/core/stream/StreamInspectAvroTest.java
+++ b/platform-api/src/test/java/io/datacater/core/stream/StreamInspectAvroTest.java
@@ -45,8 +45,7 @@ class StreamInspectAvroTest {
   UUID uuid;
 
   @Test
-  void testAvroDeserializerWithRegistry()
-      throws IOException, InterruptedException, ExecutionException, TimeoutException {
+  void testAvroDeserializerWithRegistry() throws IOException, InterruptedException {
     startWithRegistry();
 
     for (int i = 0; i <= 300; i++) {
@@ -56,12 +55,9 @@ class StreamInspectAvroTest {
               buildRecord("test" + i, 1000 + i),
               buildRecord("test" + i, 2000 + i)));
     }
-    CompletionStage<Void> lastMessageToWaitOn =
-        producerWithRegistry.send(
-            new ProducerRecord<>(
-                "streamTestWithRegistry", buildRecord("test", 1000), buildRecord("test", 2000)));
 
-    lastMessageToWaitOn.toCompletableFuture().get(2000, TimeUnit.MILLISECONDS);
+    // wait on records to finish
+    Thread.sleep(1000);
 
     Response response =
         given().pathParam("uuid", uuid.toString()).queryParam("limit", "3").get("/{uuid}/inspect");
@@ -71,8 +67,7 @@ class StreamInspectAvroTest {
   }
 
   @Test
-  void testAvroDeserializerWithSchema()
-      throws IOException, InterruptedException, ExecutionException, TimeoutException {
+  void testAvroDeserializerWithSchema() throws IOException, InterruptedException {
     startWithoutRegistry();
 
     for (int i = 1; i <= 300; i++) {
@@ -80,11 +75,9 @@ class StreamInspectAvroTest {
           new ProducerRecord(
               "streamTest", buildRecord("test" + i, 1000 + i), buildRecord("test" + i, 2000 + i)));
     }
-    Future<?> lastMessageToWaitOn =
-        producerWithSchema.send(
-            new ProducerRecord("streamTest", buildRecord("test", 1000), buildRecord("test", 2000)));
 
-    lastMessageToWaitOn.get(1000, TimeUnit.MILLISECONDS);
+    // wait on records to finish
+    Thread.sleep(1000);
 
     Response response =
         given().pathParam("uuid", uuid.toString()).queryParam("limit", "3").get("/{uuid}/inspect");

--- a/platform-api/src/test/java/io/datacater/core/stream/StreamInspectAvroTest.java
+++ b/platform-api/src/test/java/io/datacater/core/stream/StreamInspectAvroTest.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Properties;
 import java.util.UUID;
-import java.util.concurrent.*;
 import javax.inject.Inject;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;

--- a/platform-api/src/test/java/io/datacater/core/stream/StreamInspectJsonTest.java
+++ b/platform-api/src/test/java/io/datacater/core/stream/StreamInspectJsonTest.java
@@ -36,8 +36,7 @@ class StreamInspectJsonTest {
   UUID uuid;
 
   @Test
-  void testJsonDeserializer()
-      throws IOException, InterruptedException, ExecutionException, TimeoutException {
+  void testJsonDeserializer() throws IOException, InterruptedException {
     start();
 
     for (int i = 0; i <= 300; i++) {
@@ -47,12 +46,9 @@ class StreamInspectJsonTest {
               buildJson("test" + i, 1000 + i),
               buildJson("test" + i, 2000 + i)));
     }
-    CompletionStage<Void> lastMessageToWaitOn =
-        producer.send(
-            new ProducerRecord<>(
-                "testJsonDeserializer", buildJson("test", 1000), buildJson("test", 2000)));
 
-    lastMessageToWaitOn.toCompletableFuture().get(1000, TimeUnit.MILLISECONDS);
+    // wait on records to finish
+    Thread.sleep(1000);
 
     Response response =
         given().pathParam("uuid", uuid.toString()).queryParam("limit", "3").get("/{uuid}/inspect");

--- a/platform-api/src/test/java/io/datacater/core/stream/StreamInspectJsonTest.java
+++ b/platform-api/src/test/java/io/datacater/core/stream/StreamInspectJsonTest.java
@@ -15,7 +15,6 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.*;
 import javax.inject.Inject;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.eclipse.microprofile.reactive.messaging.Channel;

--- a/platform-api/src/test/java/io/datacater/core/stream/StreamInspectLongTest.java
+++ b/platform-api/src/test/java/io/datacater/core/stream/StreamInspectLongTest.java
@@ -12,10 +12,6 @@ import io.restassured.specification.RequestSpecification;
 import java.io.IOException;
 import java.net.URL;
 import java.util.UUID;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import javax.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -37,18 +33,16 @@ class StreamInspectLongTest {
   UUID uuid;
 
   @Test
-  void testLongDeserializer()
-      throws IOException, InterruptedException, ExecutionException, TimeoutException {
+  void testLongDeserializer() throws IOException, InterruptedException {
     start();
     int expectedRecordCount = 3;
 
     for (long i = 0L; i <= 300L; i++) {
       producer.send(new ProducerRecord<>("testLongDeserializer", i, i));
     }
-    CompletionStage<Void> lastMessageToWaitOn =
-        producer.send(new ProducerRecord<>("testLongDeserializer", 1000L, 2000L));
 
-    lastMessageToWaitOn.toCompletableFuture().get(1000, TimeUnit.MILLISECONDS);
+    // wait on records to finish
+    Thread.sleep(1000);
 
     Response response =
         given()

--- a/platform-api/src/test/java/io/datacater/core/stream/StreamInspectStringTest.java
+++ b/platform-api/src/test/java/io/datacater/core/stream/StreamInspectStringTest.java
@@ -12,10 +12,6 @@ import io.restassured.specification.RequestSpecification;
 import java.io.IOException;
 import java.net.URL;
 import java.util.UUID;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import javax.inject.Inject;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.eclipse.microprofile.reactive.messaging.Channel;
@@ -36,8 +32,7 @@ class StreamInspectStringTest {
   UUID uuid;
 
   @Test
-  void testStringDeserializer()
-      throws IOException, InterruptedException, ExecutionException, TimeoutException {
+  void testStringDeserializer() throws IOException, InterruptedException {
     start();
 
     for (int i = 0; i <= 300; i++) {
@@ -45,14 +40,9 @@ class StreamInspectStringTest {
           new ProducerRecord<>(
               "testStringDeserializer", String.format("test %d", i), String.format("test %d", i)));
     }
-    CompletionStage<Void> lastMessageToWaitOn =
-        producer.send(
-            new ProducerRecord<>(
-                "testStringDeserializer",
-                String.format("test %d", 1000),
-                String.format("test %d", 2000)));
 
-    lastMessageToWaitOn.toCompletableFuture().get(1000, TimeUnit.MILLISECONDS);
+    // wait on records to finish
+    Thread.sleep(1000);
 
     Response response =
         given()


### PR DESCRIPTION
This PR is to fix some tests that *sometimes* fail.

Before:
- We would send records to kafka (redpanda)
- We would wait unteil the last record has been acked to proceed with th tests
- If the last record took longer than our timeout, the test would fail

Now:
- We have remove the timeout to wait for the last record
- We now use `thread.sleep()` to wait so that most, is not all, records have been sent.
- This should solve the problem of the sporadically failing tests.