### PR TITLE
Refactor: stream, deployment, config and pipeline

### DIFF
--- a/platform-api/src/main/java/io/datacater/core/config/ConfigEndpoint.java
+++ b/platform-api/src/main/java/io/datacater/core/config/ConfigEndpoint.java
@@ -20,7 +20,6 @@ import org.hibernate.reactive.mutiny.Mutiny.SessionFactory;
 @Produces({MediaType.APPLICATION_JSON, YAMLMediaTypes.APPLICATION_JACKSON_YAML})
 @SecurityRequirement(name = "apiToken")
 public class ConfigEndpoint {
-  private static final String UUID_NOT_FOUND_ERROR_MESSAGE = "No config found for uuid %s";
 
   @Inject SessionFactory sf;
 
@@ -47,7 +46,9 @@ public class ConfigEndpoint {
                 .ifNull()
                 .failWith(
                     new ConfigNotFoundException(
-                        String.format(UUID_NOT_FOUND_ERROR_MESSAGE, uuid.toString()))));
+                        String.format(
+                            StaticConfig.LoggerMessages.UUID_NOT_FOUND_ERROR_MESSAGE_FORMATTED,
+                            uuid.toString()))));
   }
 
   @POST
@@ -77,7 +78,9 @@ public class ConfigEndpoint {
                 .ifNull()
                 .failWith(
                     new ConfigNotFoundException(
-                        String.format(UUID_NOT_FOUND_ERROR_MESSAGE, uuid.toString())))));
+                        String.format(
+                            StaticConfig.LoggerMessages.UUID_NOT_FOUND_ERROR_MESSAGE_FORMATTED,
+                            uuid.toString())))));
   }
 
   @DELETE
@@ -91,7 +94,9 @@ public class ConfigEndpoint {
                 .ifNull()
                 .failWith(
                     new ConfigNotFoundException(
-                        String.format(UUID_NOT_FOUND_ERROR_MESSAGE, uuid.toString())))
+                        String.format(
+                            StaticConfig.LoggerMessages.UUID_NOT_FOUND_ERROR_MESSAGE_FORMATTED,
+                            uuid.toString())))
                 .onItem()
                 .ifNotNull()
                 .call(session::remove)

--- a/platform-api/src/main/java/io/datacater/core/config/ConfigUtilities.java
+++ b/platform-api/src/main/java/io/datacater/core/config/ConfigUtilities.java
@@ -7,14 +7,11 @@ import io.datacater.core.stream.Stream;
 import io.datacater.core.utilities.JsonUtilities;
 import io.smallrye.mutiny.Uni;
 import java.util.*;
+import javax.enterprise.context.ApplicationScoped;
 import org.hibernate.reactive.mutiny.Mutiny;
 
+@ApplicationScoped
 public class ConfigUtilities {
-  static final String LABELS = "labels";
-  static final String KIND_DOES_NOT_MATCH_EXCEPTION_MESSAGE =
-      "The Config kind '%s' does not match that of the given resource '%s'";
-  static final String KEY_EXISTS_TWICE_EXCEPTION_MESSAGE =
-      "The key '%s' was found in at least two given Configs";
 
   private ConfigUtilities() {}
 
@@ -35,7 +32,9 @@ public class ConfigUtilities {
                     .filter(
                         item ->
                             stringMapsContainsEqualKey(
-                                JsonUtilities.toStringMap(item.getMetadata().get(LABELS)), configs))
+                                JsonUtilities.toStringMap(
+                                    item.getMetadata().get(StaticConfig.LABELS)),
+                                configs))
                     .toList())
         .onItem()
         .ifNull()
@@ -83,7 +82,10 @@ public class ConfigUtilities {
   private static void verifyKindOfConfig(Kind expected, Kind actual) {
     if (expected != actual) {
       String exceptionMessage =
-          String.format(KIND_DOES_NOT_MATCH_EXCEPTION_MESSAGE, actual, expected);
+          String.format(
+              StaticConfig.LoggerMessages.KIND_DOES_NOT_MATCH_EXCEPTION_MESSAGE_FORMATTED,
+              actual,
+              expected);
       throw new IncorrectConfigException(exceptionMessage);
     }
   }
@@ -105,7 +107,9 @@ public class ConfigUtilities {
               String duplicateKey = mapsContainsEqualKey(givenMap, currentMap);
               if (duplicateKey != null) {
                 String exceptionMessage =
-                    String.format(KEY_EXISTS_TWICE_EXCEPTION_MESSAGE, duplicateKey);
+                    String.format(
+                        StaticConfig.LoggerMessages.KEY_EXISTS_TWICE_EXCEPTION_MESSAGE,
+                        duplicateKey);
                 throw new IncorrectConfigException(exceptionMessage);
               }
             });

--- a/platform-api/src/main/java/io/datacater/core/config/StaticConfig.java
+++ b/platform-api/src/main/java/io/datacater/core/config/StaticConfig.java
@@ -1,0 +1,13 @@
+package io.datacater.core.config;
+
+public class StaticConfig {
+  static final String LABELS = "labels";
+
+  static class LoggerMessages {
+    static final String KIND_DOES_NOT_MATCH_EXCEPTION_MESSAGE_FORMATTED =
+        "The Config kind '%s' does not match that of the given resource '%s'";
+    static final String KEY_EXISTS_TWICE_EXCEPTION_MESSAGE =
+        "The key '%s' was found in at least two given Configs";
+    static final String UUID_NOT_FOUND_ERROR_MESSAGE_FORMATTED = "No config found for uuid %s";
+  }
+}

--- a/platform-api/src/main/java/io/datacater/core/deployment/DeploymentEndpoint.java
+++ b/platform-api/src/main/java/io/datacater/core/deployment/DeploymentEndpoint.java
@@ -43,6 +43,7 @@ import org.jboss.logging.Logger;
 @Path("/deployments")
 @Authenticated
 @Produces({MediaType.APPLICATION_JSON, YAMLMediaTypes.APPLICATION_JACKSON_YAML})
+//TODO needs apitoken but streams doesn't
 @SecurityRequirement(name = "apiToken")
 @RequestScoped
 public class DeploymentEndpoint {

--- a/platform-api/src/main/java/io/datacater/core/deployment/DeploymentEndpoint.java
+++ b/platform-api/src/main/java/io/datacater/core/deployment/DeploymentEndpoint.java
@@ -66,7 +66,7 @@ public class DeploymentEndpoint {
 
   @GET
   @Path("{uuid}/logs")
-  //TODO remove this produces
+  // TODO remove this produces
   @Produces(MediaType.APPLICATION_JSON)
   public Uni<List<String>> getLogs(
       @PathParam("uuid") UUID deploymentId, @DefaultValue("1") @QueryParam("replica") int replica) {
@@ -83,7 +83,7 @@ public class DeploymentEndpoint {
 
   @GET
   @Path("{uuid}/health")
-  //TODO remove this produces
+  // TODO remove this produces
   @Produces(MediaType.APPLICATION_JSON)
   public Uni<Response> getHealth(
       @PathParam("uuid") UUID deploymentId, @DefaultValue("1") @QueryParam("replica") int replica) {
@@ -173,7 +173,7 @@ public class DeploymentEndpoint {
               try {
                 watchLogsRunner(deployment.getId(), replica, sse, eventSink);
               } catch (IOException e) {
-                //TODO remove generic exception
+                // TODO remove generic exception
                 throw new DatacaterException(StringUtilities.wrapString(e.getMessage()));
               }
               return Response.ok().build();
@@ -345,14 +345,13 @@ public class DeploymentEndpoint {
                 .flatMap(entity -> entity)
                 .onFailure()
                 .transform(
-                        //TODO add logger statement for e.message
+                    // TODO add logger statement for e.message
                     ex ->
                         new UpdateDeploymentException(
                             StaticConfig.LoggerMessages.DEPLOYMENT_NOT_UPDATED))));
   }
 
-
-  //TODO move worker methods to new class(s)
+  // TODO move worker methods to new class(s)
   private Uni<PipelineEntity> getPipeline(DeploymentSpec deploymentSpec) {
     return dsf.withTransaction(
         (session, transaction) ->
@@ -397,7 +396,7 @@ public class DeploymentEndpoint {
                             .unis(Uni.createFrom().item(stream), configList)
                             .asTuple();
                       } catch (JsonProcessingException ex) {
-                        //TODO remove generic exception
+                        // TODO remove generic exception
                         throw new DatacaterException(ex.getMessage());
                       }
                     })
@@ -448,7 +447,7 @@ public class DeploymentEndpoint {
       K8Deployment k8Deployment = new K8Deployment(client);
       k8Deployment.delete(deploymentId);
     } catch (DeploymentNotFoundException e) {
-      //TODO should we handle this error?
+      // TODO should we handle this error?
       LOGGER.error(
           String.format("Could not find Kubernetes deployment with id %s", deploymentId.toString()),
           e);

--- a/platform-api/src/main/java/io/datacater/core/deployment/DeploymentEndpoint.java
+++ b/platform-api/src/main/java/io/datacater/core/deployment/DeploymentEndpoint.java
@@ -43,7 +43,6 @@ import org.jboss.logging.Logger;
 @Path("/deployments")
 @Authenticated
 @Produces({MediaType.APPLICATION_JSON, YAMLMediaTypes.APPLICATION_JACKSON_YAML})
-//TODO needs apitoken but streams doesn't
 @SecurityRequirement(name = "apiToken")
 @RequestScoped
 public class DeploymentEndpoint {
@@ -67,6 +66,7 @@ public class DeploymentEndpoint {
 
   @GET
   @Path("{uuid}/logs")
+  //TODO remove this produces
   @Produces(MediaType.APPLICATION_JSON)
   public Uni<List<String>> getLogs(
       @PathParam("uuid") UUID deploymentId, @DefaultValue("1") @QueryParam("replica") int replica) {
@@ -83,6 +83,7 @@ public class DeploymentEndpoint {
 
   @GET
   @Path("{uuid}/health")
+  //TODO remove this produces
   @Produces(MediaType.APPLICATION_JSON)
   public Uni<Response> getHealth(
       @PathParam("uuid") UUID deploymentId, @DefaultValue("1") @QueryParam("replica") int replica) {
@@ -172,6 +173,7 @@ public class DeploymentEndpoint {
               try {
                 watchLogsRunner(deployment.getId(), replica, sse, eventSink);
               } catch (IOException e) {
+                //TODO remove generic exception
                 throw new DatacaterException(StringUtilities.wrapString(e.getMessage()));
               }
               return Response.ok().build();
@@ -343,11 +345,14 @@ public class DeploymentEndpoint {
                 .flatMap(entity -> entity)
                 .onFailure()
                 .transform(
+                        //TODO add logger statement for e.message
                     ex ->
                         new UpdateDeploymentException(
                             StaticConfig.LoggerMessages.DEPLOYMENT_NOT_UPDATED))));
   }
 
+
+  //TODO move worker methods to new class(s)
   private Uni<PipelineEntity> getPipeline(DeploymentSpec deploymentSpec) {
     return dsf.withTransaction(
         (session, transaction) ->
@@ -392,6 +397,7 @@ public class DeploymentEndpoint {
                             .unis(Uni.createFrom().item(stream), configList)
                             .asTuple();
                       } catch (JsonProcessingException ex) {
+                        //TODO remove generic exception
                         throw new DatacaterException(ex.getMessage());
                       }
                     })
@@ -442,6 +448,7 @@ public class DeploymentEndpoint {
       K8Deployment k8Deployment = new K8Deployment(client);
       k8Deployment.delete(deploymentId);
     } catch (DeploymentNotFoundException e) {
+      //TODO should we handle this error?
       LOGGER.error(
           String.format("Could not find Kubernetes deployment with id %s", deploymentId.toString()),
           e);

--- a/platform-api/src/main/java/io/datacater/core/deployment/DeploymentEndpoint.java
+++ b/platform-api/src/main/java/io/datacater/core/deployment/DeploymentEndpoint.java
@@ -1,32 +1,23 @@
 package io.datacater.core.deployment;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.jaxrs.yaml.YAMLMediaTypes;
 import io.datacater.core.authentication.DataCaterSessionFactory;
-import io.datacater.core.config.ConfigEntity;
 import io.datacater.core.config.ConfigUtilities;
 import io.datacater.core.exceptions.*;
-import io.datacater.core.pipeline.PipelineEntity;
-import io.datacater.core.stream.Stream;
-import io.datacater.core.stream.StreamEntity;
+import io.datacater.core.pipeline.PipelineUtilities;
+import io.datacater.core.stream.StreamUtilities;
+import io.datacater.core.utilities.LoggerUtilities;
 import io.datacater.core.utilities.StringUtilities;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.dsl.ContainerResource;
-import io.fabric8.kubernetes.client.dsl.LogWatch;
 import io.quarkus.security.Authenticated;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.unchecked.Unchecked;
 import java.io.*;
-import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
@@ -34,7 +25,6 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.sse.OutboundSseEvent;
 import javax.ws.rs.sse.Sse;
 import javax.ws.rs.sse.SseEventSink;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
@@ -46,11 +36,11 @@ import org.jboss.logging.Logger;
 @SecurityRequirement(name = "apiToken")
 @RequestScoped
 public class DeploymentEndpoint {
-
   @Inject DataCaterSessionFactory dsf;
-
+  @Inject DeploymentUtilities deploymentsUtil;
+  @Inject StreamUtilities streamUtil;
+  @Inject PipelineUtilities pipelineUtil;
   static final Logger LOGGER = Logger.getLogger(DeploymentEndpoint.class);
-
   @Inject KubernetesClient client;
 
   @GET
@@ -66,8 +56,6 @@ public class DeploymentEndpoint {
 
   @GET
   @Path("{uuid}/logs")
-  // TODO remove this produces
-  @Produces(MediaType.APPLICATION_JSON)
   public Uni<List<String>> getLogs(
       @PathParam("uuid") UUID deploymentId, @DefaultValue("1") @QueryParam("replica") int replica) {
     return dsf.withTransaction(
@@ -78,13 +66,13 @@ public class DeploymentEndpoint {
         .onItem()
         .ifNotNull()
         .transform(
-            Unchecked.function(deployment -> getDeploymentLogsAsList(deployment.getId(), replica)));
+            Unchecked.function(
+                deployment ->
+                    deploymentsUtil.getDeploymentLogsAsList(deployment.getId(), replica)));
   }
 
   @GET
   @Path("{uuid}/health")
-  // TODO remove this produces
-  @Produces(MediaType.APPLICATION_JSON)
   public Uni<Response> getHealth(
       @PathParam("uuid") UUID deploymentId, @DefaultValue("1") @QueryParam("replica") int replica) {
     return dsf.withTransaction(
@@ -99,7 +87,7 @@ public class DeploymentEndpoint {
                 deployment -> {
                   HttpClient httpClient = HttpClient.newHttpClient();
                   HttpRequest req =
-                      buildDeploymentServiceRequest(
+                      deploymentsUtil.buildDeploymentServiceRequest(
                           deploymentId,
                           StaticConfig.EnvironmentVariables.DEPLOYMENT_HEALTH_PATH,
                           replica);
@@ -126,7 +114,7 @@ public class DeploymentEndpoint {
                 deployment -> {
                   HttpClient httpClient = HttpClient.newHttpClient();
                   HttpRequest req =
-                      buildDeploymentServiceRequest(
+                      deploymentsUtil.buildDeploymentServiceRequest(
                           deploymentId,
                           StaticConfig.EnvironmentVariables.DEPLOYMENT_METRICS_PATH,
                           replica);
@@ -171,9 +159,8 @@ public class DeploymentEndpoint {
         .transform(
             deployment -> {
               try {
-                watchLogsRunner(deployment.getId(), replica, sse, eventSink);
+                deploymentsUtil.watchLogsRunner(deployment.getId(), replica, sse, eventSink);
               } catch (IOException e) {
-                // TODO remove generic exception
                 throw new DatacaterException(StringUtilities.wrapString(e.getMessage()));
               }
               return Response.ok().build();
@@ -214,7 +201,7 @@ public class DeploymentEndpoint {
                           .all()
                           .unis(
                               Uni.createFrom().item(combinedSpec),
-                              getPipeline(combinedSpec),
+                              pipelineUtil.getPipelineFromDeployment(combinedSpec),
                               Uni.createFrom().item(tuple.getItem1()))
                           .asTuple();
                     })
@@ -225,12 +212,12 @@ public class DeploymentEndpoint {
                             .all()
                             .unis(
                                 Uni.createFrom().item(tuple.getItem2()),
-                                getStream(
+                                streamUtil.getStreamFromDeployment(
                                     tuple.getItem1(),
                                     StaticConfig.STREAM_IN_CONFIG,
                                     tuple.getItem2(),
                                     StaticConfig.STREAM_IN),
-                                getStream(
+                                streamUtil.getStreamFromDeployment(
                                     tuple.getItem1(),
                                     StaticConfig.STREAM_OUT_CONFIG,
                                     tuple.getItem2(),
@@ -241,7 +228,7 @@ public class DeploymentEndpoint {
                 .onItem()
                 .transform(
                     tuple ->
-                        createDeployment(
+                        deploymentsUtil.createDeployment(
                             tuple.getItem1(),
                             tuple.getItem3(),
                             tuple.getItem2(),
@@ -266,7 +253,7 @@ public class DeploymentEndpoint {
                 .ifNotNull()
                 .call(
                     de -> {
-                      deleteK8Deployment(deploymentId);
+                      deploymentsUtil.deleteK8Deployment(deploymentId);
                       return session.remove(de);
                     })
                 .replaceWith(Response.ok().build())));
@@ -304,7 +291,7 @@ public class DeploymentEndpoint {
                           .all()
                           .unis(
                               Uni.createFrom().item(combinedSpec),
-                              getPipeline(combinedSpec),
+                              pipelineUtil.getPipelineFromDeployment(combinedSpec),
                               Uni.createFrom().item(tuple.getItem1()),
                               Uni.createFrom().item(tuple.getItem2()))
                           .asTuple();
@@ -316,12 +303,12 @@ public class DeploymentEndpoint {
                             .all()
                             .unis(
                                 Uni.createFrom().item(tuple.getItem2()),
-                                getStream(
+                                streamUtil.getStreamFromDeployment(
                                     tuple.getItem1(),
                                     StaticConfig.STREAM_IN_CONFIG,
                                     tuple.getItem2(),
                                     StaticConfig.STREAM_IN),
-                                getStream(
+                                streamUtil.getStreamFromDeployment(
                                     tuple.getItem1(),
                                     StaticConfig.STREAM_OUT_CONFIG,
                                     tuple.getItem2(),
@@ -333,7 +320,7 @@ public class DeploymentEndpoint {
                 .onItem()
                 .transform(
                     tuple -> {
-                      updateDeployment(
+                      deploymentsUtil.updateDeployment(
                           tuple.getItem1(),
                           tuple.getItem3(),
                           tuple.getItem2(),
@@ -345,189 +332,13 @@ public class DeploymentEndpoint {
                 .flatMap(entity -> entity)
                 .onFailure()
                 .transform(
-                    // TODO add logger statement for e.message
-                    ex ->
-                        new UpdateDeploymentException(
-                            StaticConfig.LoggerMessages.DEPLOYMENT_NOT_UPDATED))));
-  }
-
-  // TODO move worker methods to new class(s)
-  private Uni<PipelineEntity> getPipeline(DeploymentSpec deploymentSpec) {
-    return dsf.withTransaction(
-        (session, transaction) ->
-            session
-                .find(PipelineEntity.class, getPipelineUUIDFromMap(deploymentSpec.deployment()))
-                .onItem()
-                .ifNull()
-                .failWith(
-                    new CreateDeploymentException(StaticConfig.LoggerMessages.PIPELINE_NOT_FOUND)));
-  }
-
-  private Uni<DeploymentEntity> getDeploymentUni(UUID deploymentUuid) {
-    return dsf.withTransaction(
-        (session, transaction) ->
-            session
-                .find(DeploymentEntity.class, deploymentUuid)
-                .onItem()
-                .ifNull()
-                .failWith(
-                    new CreateDeploymentException(
-                        StaticConfig.LoggerMessages.DEPLOYMENT_NOT_FOUND)));
-  }
-
-  private Uni<Stream> getStream(
-      DeploymentSpec spec, String deploymentSpecKey, PipelineEntity pipeline, String key) {
-    return dsf.withTransaction(
-        (session, transaction) ->
-            session
-                .find(
-                    StreamEntity.class,
-                    getStreamUUID(spec, deploymentSpecKey, pipeline.getMetadata(), key))
-                .onItem()
-                .ifNotNull()
-                .transformToUni(
-                    entity -> {
-                      try {
-                        Stream stream = Stream.from(entity);
-                        Uni<List<ConfigEntity>> configList =
-                            ConfigUtilities.getMappedConfigs(stream.configSelector(), session);
-                        return Uni.combine()
-                            .all()
-                            .unis(Uni.createFrom().item(stream), configList)
-                            .asTuple();
-                      } catch (JsonProcessingException ex) {
-                        // TODO remove generic exception
-                        throw new DatacaterException(ex.getMessage());
-                      }
-                    })
-                .onItem()
-                .ifNotNull()
-                .transform(
-                    tuple -> {
-                      Stream stream = tuple.getItem1();
-                      stream = ConfigUtilities.applyConfigsToStream(stream, tuple.getItem2());
-                      return stream;
-                    })
-                .onItem()
-                .ifNull()
-                .failWith(
-                    new CreateDeploymentException(
-                        String.format(StaticConfig.LoggerMessages.STREAM_NOT_FOUND, key))));
-  }
-
-  private List<String> getDeploymentLogsAsList(UUID deploymentId, int replica) {
-    K8Deployment k8Deployment = new K8Deployment(client);
-    return Arrays.asList(k8Deployment.getLogs(deploymentId, replica).split("\n"));
-  }
-
-  private HttpRequest buildDeploymentServiceRequest(UUID deploymentId, String path, int replica) {
-    K8Deployment k8Deployment = new K8Deployment(client);
-    String ip = k8Deployment.getDeploymentReplicaIp(deploymentId, replica).replace(".", "-");
-    String namespace = StaticConfig.EnvironmentVariables.NAMESPACE;
-    int port = StaticConfig.EnvironmentVariables.DEPLOYMENT_CONTAINER_PORT;
-    String protocol = StaticConfig.EnvironmentVariables.DEPLOYMENT_CONTAINER_PROTOCOL;
-
-    String uriReady =
-        String.format("%s://%s.%s.pod.cluster.local:%d%s", protocol, ip, namespace, port, path);
-
-    return HttpRequest.newBuilder()
-        .GET()
-        .version(HttpClient.Version.HTTP_1_1)
-        .uri(URI.create(uriReady))
-        .build();
-  }
-
-  private ContainerResource watchDeploymentLogs(UUID deploymentId, int replica) {
-    K8Deployment k8Deployment = new K8Deployment(client);
-    return k8Deployment.watchLogs(deploymentId, replica);
-  }
-
-  private void deleteK8Deployment(UUID deploymentId) {
-    try {
-      K8Deployment k8Deployment = new K8Deployment(client);
-      k8Deployment.delete(deploymentId);
-    } catch (DeploymentNotFoundException e) {
-      // TODO should we handle this error?
-      LOGGER.error(
-          String.format("Could not find Kubernetes deployment with id %s", deploymentId.toString()),
-          e);
-    }
-  }
-
-  private DeploymentEntity createDeployment(
-      PipelineEntity pe,
-      Stream streamOut,
-      Stream streamIn,
-      DeploymentSpec deploymentSpec,
-      DeploymentEntity de,
-      List<ConfigEntity> configList) {
-    K8Deployment k8Deployment = new K8Deployment(client);
-    DeploymentSpec specWithConfig =
-        ConfigUtilities.applyConfigsToDeployment(DeploymentSpec.from(deploymentSpec), configList);
-
-    k8Deployment.create(pe, streamIn, streamOut, specWithConfig, de.getId());
-
-    return de;
-  }
-
-  private DeploymentEntity updateDeployment(
-      PipelineEntity pe,
-      Stream streamOut,
-      Stream streamIn,
-      DeploymentSpec deploymentSpec,
-      DeploymentEntity de,
-      List<ConfigEntity> configList) {
-    deleteK8Deployment(de.getId());
-    return createDeployment(pe, streamOut, streamIn, deploymentSpec, de, configList);
-  }
-
-  private UUID getStreamUUID(
-      DeploymentSpec spec, String deploymentSpecKey, JsonNode node, String key) {
-    // try and get from deploymentSpec
-    String uuidString = "";
-    ObjectMapper mapper = new ObjectMapper();
-    Map<String, Object> streamConfig =
-        mapper.convertValue(spec.deployment().get(deploymentSpecKey), Map.class);
-    if (streamConfig != null && streamConfig.get("uuid") != null) {
-      uuidString = streamConfig.get("uuid").toString();
-    }
-
-    // if not in deploymentSpec, try and get from pipeline
-    if ((uuidString == null || uuidString.isEmpty() || uuidString.isBlank())
-        && node.get(key) != null) {
-      uuidString = node.get(key).asText();
-    }
-
-    // if in neither, throw exception
-    if (uuidString == null || uuidString.isEmpty() || uuidString.isBlank()) {
-      throw new CreateDeploymentException(
-          String.format(StaticConfig.LoggerMessages.STREAM_NOT_FOUND, key));
-    }
-
-    return UUID.fromString(uuidString);
-  }
-
-  private UUID getPipelineUUIDFromMap(Map<String, Object> map) {
-    try {
-      return UUID.fromString(map.get(StaticConfig.PIPELINE_NODE_TEXT).toString());
-    } catch (Exception e) {
-      throw new CreateDeploymentException(StaticConfig.LoggerMessages.PIPELINE_NOT_FOUND);
-    }
-  }
-
-  private void watchLogsRunner(
-      UUID deploymentId, int replica, @Context Sse sse, @Context SseEventSink eventSink)
-      throws IOException {
-    LogWatch lw = watchDeploymentLogs(deploymentId, replica).watchLog();
-    InputStream is = lw.getOutput();
-    BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(is));
-    String line;
-    while ((line = bufferedReader.readLine()) != null) {
-      final OutboundSseEvent sseEvent = sse.newEventBuilder().data(line).build();
-
-      eventSink.send(sseEvent);
-    }
-    is.close();
-    lw.close();
+                    ex -> {
+                      LoggerUtilities.logExceptionMessage(
+                          LOGGER,
+                          new Throwable().getStackTrace()[0].getMethodName(),
+                          ex.getMessage());
+                      throw new UpdateDeploymentException(
+                          StaticConfig.LoggerMessages.DEPLOYMENT_NOT_UPDATED);
+                    })));
   }
 }

--- a/platform-api/src/main/java/io/datacater/core/deployment/DeploymentUtilities.java
+++ b/platform-api/src/main/java/io/datacater/core/deployment/DeploymentUtilities.java
@@ -1,0 +1,118 @@
+package io.datacater.core.deployment;
+
+import io.datacater.core.config.ConfigEntity;
+import io.datacater.core.config.ConfigUtilities;
+import io.datacater.core.exceptions.DeploymentNotFoundException;
+import io.datacater.core.pipeline.PipelineEntity;
+import io.datacater.core.stream.Stream;
+import io.datacater.core.utilities.LoggerUtilities;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.ContainerResource;
+import io.fabric8.kubernetes.client.dsl.LogWatch;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.sse.OutboundSseEvent;
+import javax.ws.rs.sse.Sse;
+import javax.ws.rs.sse.SseEventSink;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+public class DeploymentUtilities {
+  static final Logger LOGGER = Logger.getLogger(DeploymentUtilities.class);
+
+  @Inject KubernetesClient client;
+
+  public List<String> getDeploymentLogsAsList(UUID deploymentId, int replica) {
+    K8Deployment k8Deployment = new K8Deployment(client);
+    return Arrays.asList(k8Deployment.getLogs(deploymentId, replica).split("\n"));
+  }
+
+  public HttpRequest buildDeploymentServiceRequest(UUID deploymentId, String path, int replica) {
+    K8Deployment k8Deployment = new K8Deployment(client);
+    String ip = k8Deployment.getDeploymentReplicaIp(deploymentId, replica).replace(".", "-");
+    String namespace = StaticConfig.EnvironmentVariables.NAMESPACE;
+    int port = StaticConfig.EnvironmentVariables.DEPLOYMENT_CONTAINER_PORT;
+    String protocol = StaticConfig.EnvironmentVariables.DEPLOYMENT_CONTAINER_PROTOCOL;
+
+    String uriReady =
+        String.format("%s://%s.%s.pod.cluster.local:%d%s", protocol, ip, namespace, port, path);
+
+    return HttpRequest.newBuilder()
+        .GET()
+        .version(HttpClient.Version.HTTP_1_1)
+        .uri(URI.create(uriReady))
+        .build();
+  }
+
+  public ContainerResource watchDeploymentLogs(UUID deploymentId, int replica) {
+    K8Deployment k8Deployment = new K8Deployment(client);
+    return k8Deployment.watchLogs(deploymentId, replica);
+  }
+
+  public void deleteK8Deployment(UUID deploymentId) {
+    try {
+      K8Deployment k8Deployment = new K8Deployment(client);
+      k8Deployment.delete(deploymentId);
+    } catch (DeploymentNotFoundException e) {
+      LoggerUtilities.logExceptionMessage(
+          LOGGER,
+          new Throwable().getStackTrace()[0].getMethodName(),
+          String.format(
+              "Could not find Kubernetes deployment with id %s", deploymentId.toString()));
+    }
+  }
+
+  public DeploymentEntity createDeployment(
+      PipelineEntity pe,
+      Stream streamOut,
+      Stream streamIn,
+      DeploymentSpec deploymentSpec,
+      DeploymentEntity de,
+      List<ConfigEntity> configList) {
+    K8Deployment k8Deployment = new K8Deployment(client);
+    DeploymentSpec specWithConfig =
+        ConfigUtilities.applyConfigsToDeployment(DeploymentSpec.from(deploymentSpec), configList);
+
+    k8Deployment.create(pe, streamIn, streamOut, specWithConfig, de.getId());
+
+    return de;
+  }
+
+  public void updateDeployment(
+      PipelineEntity pe,
+      Stream streamOut,
+      Stream streamIn,
+      DeploymentSpec deploymentSpec,
+      DeploymentEntity de,
+      List<ConfigEntity> configList) {
+    deleteK8Deployment(de.getId());
+    createDeployment(pe, streamOut, streamIn, deploymentSpec, de, configList);
+  }
+
+  public void watchLogsRunner(
+      UUID deploymentId, int replica, @Context Sse sse, @Context SseEventSink eventSink)
+      throws IOException {
+    LogWatch lw = watchDeploymentLogs(deploymentId, replica).watchLog();
+    InputStream is = lw.getOutput();
+    BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(is));
+    String line;
+    while ((line = bufferedReader.readLine()) != null) {
+      final OutboundSseEvent sseEvent = sse.newEventBuilder().data(line).build();
+
+      eventSink.send(sseEvent);
+    }
+    is.close();
+    lw.close();
+  }
+}

--- a/platform-api/src/main/java/io/datacater/core/deployment/StaticConfig.java
+++ b/platform-api/src/main/java/io/datacater/core/deployment/StaticConfig.java
@@ -22,7 +22,6 @@ public class StaticConfig {
   static final String PIPELINE_REV = "1";
   static final String UUID_TEXT = "datacater.io/uuid";
   static final String DEPLOYMENT_NAME_TEXT = "datacater.io/name";
-  static final String DEPLOYMENT_SERVICE_TEXT = "datacater.io/service";
   static final String CONFIGMAP_MOUNT_PATH = "/usr/app/mounts";
   static final String DATA_SHARE_MOUNT_PATH = "/usr/app/data-mounts";
   public static final String MEMORY = "memory";
@@ -51,14 +50,11 @@ public class StaticConfig {
   static final String CONFIGMAP_NAME_PREFIX = "datacater-configmap-";
   static final String CONFIGMAP_VOLUME_NAME_PREFIX = "datacater-volume-";
   static final String DATA_SHARE_VOLUME_NAME_PREFIX = "datacater-volume-data-";
-  static final String SERVICE_NAME_PREFIX = "datacater-service-";
-  static final String TCP_TAG = "TCP";
   static final String SPEC = "spec";
   static final String STREAM_OUT = "stream-out";
   static final String STREAM_IN = "stream-in";
   static final String STREAM_IN_CONFIG = "stream-in-config";
   static final String STREAM_OUT_CONFIG = "stream-out-config";
-  static final String PIPELINE_NODE_TEXT = "pipeline";
   static final String SERIALIZER = "serializer";
   static final String DESERIALIZER = "deserializer";
   static final String EMPTY_STRING = "";
@@ -152,8 +148,6 @@ public class StaticConfig {
 
     static final String DEPLOYMENT_DELETED = "Datacater Deployment deleted successfully: %s";
     static final String DEPLOYMENT_NOT_DELETED = "Datacater Deployment could not be deleted: %s";
-    static final String PIPELINE_NOT_FOUND = "The referenced Pipeline UUID could not be found";
-    static final String STREAM_NOT_FOUND = "The referenced %s UUID could not be found";
     static final String DEPLOYMENT_NOT_FOUND = "The referenced Deployment could not be found.";
     static final String K8_DEPLOYMENT_NOT_FOUND =
         "The referenced Kubernetes Deployment could not be found.";

--- a/platform-api/src/main/java/io/datacater/core/exceptions/DeleteStreamException.java
+++ b/platform-api/src/main/java/io/datacater/core/exceptions/DeleteStreamException.java
@@ -1,0 +1,10 @@
+package io.datacater.core.exceptions;
+
+import io.datacater.core.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+public class DeleteStreamException extends RuntimeException {
+  public DeleteStreamException(String message) {
+    super(message);
+  }
+}

--- a/platform-api/src/main/java/io/datacater/core/exceptions/DeleteStreamExceptionMapper.java
+++ b/platform-api/src/main/java/io/datacater/core/exceptions/DeleteStreamExceptionMapper.java
@@ -1,0 +1,20 @@
+package io.datacater.core.exceptions;
+
+import io.datacater.core.ExcludeFromGeneratedCoverageReport;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@ExcludeFromGeneratedCoverageReport
+@Provider
+public class DeleteStreamExceptionMapper implements ExceptionMapper<DeleteStreamException> {
+
+  public Response toResponse(DeleteStreamException exception) {
+    Error error =
+        Error.from(
+            Response.Status.BAD_REQUEST.getStatusCode(),
+            Response.Status.BAD_REQUEST,
+            exception.getMessage());
+    return Response.status(Response.Status.BAD_REQUEST).entity(error).build();
+  }
+}

--- a/platform-api/src/main/java/io/datacater/core/pipeline/PipelineUtilities.java
+++ b/platform-api/src/main/java/io/datacater/core/pipeline/PipelineUtilities.java
@@ -1,0 +1,105 @@
+package io.datacater.core.pipeline;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.datacater.core.authentication.DataCaterSessionFactory;
+import io.datacater.core.deployment.DeploymentSpec;
+import io.datacater.core.exceptions.CreateDeploymentException;
+import io.datacater.core.kubernetes.PythonRunnerPool;
+import io.datacater.core.stream.StreamMessage;
+import io.datacater.core.stream.StreamUtilities;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.tuples.Tuple3;
+import io.smallrye.mutiny.unchecked.Unchecked;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+public class PipelineUtilities {
+  @Inject PythonRunnerPool runnerPool;
+  static final Logger LOGGER = Logger.getLogger(PipelineUtilities.class);
+  @Inject DataCaterSessionFactory dsf;
+  @Inject StreamUtilities streamUtil;
+
+  public Uni<String> transformMessages(UUID uuid) {
+    HttpClient httpClient = HttpClient.newHttpClient();
+
+    Uni<PipelineEntity> pe = dsf.withSession(session -> session.find(PipelineEntity.class, uuid));
+    Uni<List<StreamMessage>> messages =
+        pe.flatMap(
+            pipelineEntity -> {
+              JsonNode streamIn = pipelineEntity.getMetadata().get(StaticConfig.STREAM_IN_TEXT);
+              UUID streamUUID = UUID.fromString(streamIn.asText());
+              return streamUtil.getStreamMessages(streamUUID);
+            });
+
+    Uni<PythonRunnerPool.NamedPod> namedPodAsync = runnerPool.getStaticPod();
+    Uni<Tuple3<PipelineEntity, List<StreamMessage>, PythonRunnerPool.NamedPod>> combinedPeMsg =
+        Uni.combine().all().unis(pe, messages, namedPodAsync).asTuple();
+
+    return combinedPeMsg.flatMap(
+        Unchecked.function(
+            peMsg -> {
+              PipelineEntity entity = peMsg.getItem1();
+              List<StreamMessage> msgs = peMsg.getItem2();
+              PythonRunnerPool.NamedPod namedPod = peMsg.getItem3();
+
+              HttpRequest specPost =
+                  namedPod.buildPost(entity.asJsonString(), StaticConfig.PIPELINE_PATH);
+              CompletableFuture<HttpResponse<String>> specResponse =
+                  httpClient.sendAsync(specPost, HttpResponse.BodyHandlers.ofString());
+
+              LOGGER.info(specPost.uri().toString());
+              StreamMessage recordMessagePayload = msgs.get(0);
+              String messagesPayload = recordMessagePayload.toRecordJsonString();
+              HttpRequest transformPost = namedPod.buildPost(messagesPayload);
+
+              LOGGER.info(StaticConfig.PAYLOAD_SENT_UPDATE_MSG);
+              LOGGER.info(messagesPayload);
+              CompletableFuture<HttpResponse<String>> transformResponse =
+                  httpClient.sendAsync(transformPost, HttpResponse.BodyHandlers.ofString());
+
+              Uni<HttpResponse<String>> transform =
+                  Uni.createFrom().completionStage(transformResponse);
+              return Uni.createFrom()
+                  .completionStage(specResponse)
+                  .map(
+                      response -> {
+                        String message =
+                            String.format(
+                                StaticConfig.FormattedMessages.RECEIVED_RESPONSE_FORMATTED_MSG,
+                                response.request().uri(),
+                                response.statusCode());
+                        LOGGER.info(message);
+                        return response.body();
+                      })
+                  .flatMap(specPostResponse -> transform)
+                  .map(HttpResponse::body);
+            }));
+  }
+
+  public Uni<PipelineEntity> getPipelineFromDeployment(DeploymentSpec deploymentSpec) {
+    return dsf.withTransaction(
+        (session, transaction) ->
+            session
+                .find(PipelineEntity.class, getPipelineUUIDFromMap(deploymentSpec.deployment()))
+                .onItem()
+                .ifNull()
+                .failWith(new CreateDeploymentException(StaticConfig.PIPELINE_NOT_FOUND)));
+  }
+
+  public UUID getPipelineUUIDFromMap(Map<String, Object> map) {
+    try {
+      return UUID.fromString(map.get(StaticConfig.PIPELINE_NODE_TEXT).toString());
+    } catch (Exception e) {
+      throw new CreateDeploymentException(StaticConfig.PIPELINE_NOT_FOUND);
+    }
+  }
+}

--- a/platform-api/src/main/java/io/datacater/core/pipeline/StaticConfig.java
+++ b/platform-api/src/main/java/io/datacater/core/pipeline/StaticConfig.java
@@ -1,0 +1,17 @@
+package io.datacater.core.pipeline;
+
+public class StaticConfig {
+  static final String PIPELINE_NOT_FOUND = "The referenced Pipeline UUID could not be found";
+  static final String PIPELINE_NODE_TEXT = "pipeline";
+  static final String STREAM_IN_TEXT = "stream-in";
+  static final String PIPELINE_PATH = "/pipeline";
+  static final String PAYLOAD_SENT_UPDATE_MSG = "Will send following payload after spec update";
+  static final String PREVIEW_PATH = "/preview";
+
+  public class FormattedMessages {
+    static final String PYTHON_RUNNER_TIMEOUT_FORMATTED_MSG =
+        "Calling the Python runner exceeded the timeout of datacater.pythonrunner.preview.timeout=%d.";
+    static final String RECEIVED_RESPONSE_FORMATTED_MSG =
+        "Received response from %s with status %d";
+  }
+}

--- a/platform-api/src/main/java/io/datacater/core/stream/SampleMethod.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/SampleMethod.java
@@ -4,6 +4,5 @@ public enum SampleMethod {
   UNIFORM("uniform"),
   SEQUENCED("sequenced");
 
-  SampleMethod(String method) {
-  }
+  SampleMethod(String method) {}
 }

--- a/platform-api/src/main/java/io/datacater/core/stream/SampleMethod.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/SampleMethod.java
@@ -4,9 +4,6 @@ public enum SampleMethod {
   UNIFORM("uniform"),
   SEQUENCED("sequenced");
 
-  private final String method;
-
   SampleMethod(String method) {
-    this.method = method;
   }
 }

--- a/platform-api/src/main/java/io/datacater/core/stream/StaticConfig.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/StaticConfig.java
@@ -1,0 +1,58 @@
+package io.datacater.core.stream;
+
+import java.util.Optional;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+public class StaticConfig {
+  static final String DATACATER_PREFIX = "datacater-";
+  static final String PARTITION_COUNT = "num.partitions";
+  static final String REPLICATION_FACTOR = "replication.factor";
+  static final String VALUE_DESERIALIZER_TEXT = "value.deserializer";
+  static final String KEY_DESERIALIZER_TEXT = "key.deserializer";
+  static final String FALSE = "false";
+  static final String RECORD_TAG = "record";
+  static final String TOPIC_KEY = "topic";
+  static final String CONFIG_KEY = "config";
+  static final String UUID_TEXT = "uuid";
+  static final String PARTITION_TEXT = "partition";
+  static final String OFFSET_TEXT = "offset";
+  static final String TIMESTAMP_TEXT = "timestamp";
+  static final String MAX_POLL_RECORDS = "max.poll.records";
+
+  static class EnvironmentVariables {
+    static final Optional<String> DEFAULT_TOPIC_NAME =
+        ConfigProvider.getConfig()
+            .getOptionalValue("datacater.kafka.default-topic-name", String.class);
+    static final Integer DEFAULT_NUM_PARTITIONS =
+        ConfigProvider.getConfig()
+            .getOptionalValue("datacater.kafka.default-num-partitions", Integer.class)
+            .orElse(3);
+    static final Short DEFAULT_REPLICATION_FACTOR =
+        ConfigProvider.getConfig()
+            .getOptionalValue("datacater.kafka.default-replication-factor", Short.class)
+            .orElse((short) 1);
+
+    static final Integer KAFKA_API_TIMEOUT_MS =
+        ConfigProvider.getConfig()
+            .getOptionalValue("datacater.kafka.api.timeout.ms", Integer.class)
+            .orElse(5000);
+  }
+
+  static class LoggerMessages {
+    static final String streamDeleteNotFinishedMessage =
+        "Stream deletion was called without errors but has not finished yet.";
+    static final String streamNotFoundMessage = "Stream not found.";
+    static final String STREAM_NOT_FOUND = "The referenced %s UUID could not be found";
+    static final String KAFKA_TOPIC_METADATA_NOT_MAPPED =
+        "Kafka topic metadata could not be mapped.";
+    static final String KAFKA_TOPIC_METADATA_NOT_MAPPED_INTERRUPTED =
+        "Kafka topic metadata could not be mapped. The execution thread was interrupted.";
+    static final String KAFKA_BROKER_UNAVAILABLE =
+        "Connection to node could not be established. Broker may not be available.";
+    static final String THREAD_INTERRUPTED = "Thread got interrupted: ";
+    static final String TOPIC_UPDATE_TIMEOUT_FORMATTED =
+        "Exceeded timeout of %d ms when updating the config of the Apache Kafka topic.";
+    static final String STREAM_NOT_CREATED_METADATA_MISMATCH_FORMATTED =
+        "Could not create stream as it already exists on the Cluster and the given metadata doesn't match the actual metadata: %s";
+  }
+}

--- a/platform-api/src/main/java/io/datacater/core/stream/StreamEndpoint.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/StreamEndpoint.java
@@ -26,7 +26,7 @@ import org.jboss.logging.Logger;
 public class StreamEndpoint {
   private static final Logger LOGGER = Logger.getLogger(StreamEndpoint.class);
   @Inject DataCaterSessionFactory dsf;
-  @Inject StreamsUtilities streamsUtil;
+  @Inject StreamUtilities streamUtil;
 
   @GET
   @Path("{uuid}")
@@ -34,7 +34,7 @@ public class StreamEndpoint {
     return dsf.withTransaction(((session, transaction) -> session.find(StreamEntity.class, uuid)))
         .onItem()
         .ifNull()
-        .failWith(new StreamNotFoundException(StreamsUtilities.streamNotFoundMessage));
+        .failWith(new StreamNotFoundException(StaticConfig.LoggerMessages.streamNotFoundMessage));
   }
 
   @GET
@@ -43,7 +43,7 @@ public class StreamEndpoint {
       @PathParam("uuid") UUID uuid,
       @DefaultValue("100") @QueryParam("limit") Long limit,
       @DefaultValue("SEQUENCED") @QueryParam("sampleMethod") SampleMethod sampleMethod) {
-    return streamsUtil.getStreamMessages(uuid, limit, sampleMethod);
+    return streamUtil.getStreamMessages(uuid, limit, sampleMethod);
   }
 
   @GET
@@ -68,7 +68,7 @@ public class StreamEndpoint {
                     .onItem()
                     .transform(
                         configEntities -> {
-                          streamsUtil.createStreamObject(stream, configEntities);
+                          streamUtil.createStreamObject(stream, configEntities);
                           return configEntities;
                         })
                     .replaceWith(Response.ok(se).build()))
@@ -105,7 +105,7 @@ public class StreamEndpoint {
                 .transform(
                     tuple -> {
                       try {
-                        streamsUtil.updateStreamObject(stream, tuple.getItem2());
+                        streamUtil.updateStreamObject(stream, tuple.getItem2());
                         return session.merge((tuple.getItem1()).updateEntity(stream));
                       } catch (JsonProcessingException e) {
                         LoggerUtilities.logExceptionMessage(
@@ -160,7 +160,7 @@ public class StreamEndpoint {
                 .call(
                     tuple -> {
                       if (Boolean.TRUE.equals(force)) {
-                        streamsUtil.deleteStreamObject(tuple.getItem1(), tuple.getItem2());
+                        streamUtil.deleteStreamObject(tuple.getItem1(), tuple.getItem2());
                       }
                       return session.remove(tuple.getItem3());
                     })

--- a/platform-api/src/main/java/io/datacater/core/stream/StreamEndpoint.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/StreamEndpoint.java
@@ -77,6 +77,7 @@ public class StreamEndpoint {
                             ConfigUtilities.getMappedConfigs(stream.configSelector(), session))
                     .onItem()
                     .transform(
+                            //TODO can refactor createStreamObject to return the configentities, for a one-liner?
                         configEntities -> {
                           createStreamObject(stream, configEntities);
                           return configEntities;
@@ -84,6 +85,7 @@ public class StreamEndpoint {
                     .replaceWith(Response.ok(se).build()))
         .onFailure()
         .transform(
+                //TODO add logger statement for e.message
             ex -> new CreateStreamException(exceptionCauseMessageIfAvailable((Exception) ex)));
   }
 
@@ -114,6 +116,7 @@ public class StreamEndpoint {
                         return session.merge((tuple.getItem1()).updateEntity(stream));
                       } catch (JsonProcessingException e) {
                         //TODO dont throw generic exceptions
+                        //TODO add logger statement for e.message
                         throw new RuntimeException(e);
                       }
                     })
@@ -121,6 +124,7 @@ public class StreamEndpoint {
                 .onFailure()
                 .transform(
                     ex ->
+                            //TODO add logger statement for e.message
                         new UpdateStreamException(
                             exceptionCauseMessageIfAvailable((Exception) ex)))));
   }
@@ -189,6 +193,7 @@ public class StreamEndpoint {
     } catch (TimeoutException e) {
       //TODO no magic string
       //TODO is it ok to drop exception instead of handling it?
+      //TODO add logger statement for e.message
       LOGGER.info("Stream deletion was called without errors but has not finished yet.");
     }
   }
@@ -202,6 +207,7 @@ public class StreamEndpoint {
 
   //TODO move this method to generic utility class
   private static String exceptionCauseMessageIfAvailable(Exception ex) {
+    //TODO add logger statement for e.message
     if (ex.getCause() == null) {
       return ex.getMessage();
     }

--- a/platform-api/src/main/java/io/datacater/core/stream/StreamMessage.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/StreamMessage.java
@@ -20,7 +20,7 @@ public record StreamMessage(Object key, Object value, Map<String, Object> metada
   public String toRecordJsonString() throws JsonProcessingException {
     ObjectMapper mapper = new ObjectMapper();
     ObjectNode rootNode = mapper.createObjectNode();
-    ObjectNode all = rootNode.putPOJO("record", this);
+    ObjectNode all = rootNode.putPOJO(StaticConfig.RECORD_TAG, this);
     return mapper.writeValueAsString(all);
   }
 }

--- a/platform-api/src/main/java/io/datacater/core/stream/StreamSpec.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/StreamSpec.java
@@ -56,11 +56,12 @@ public class StreamSpec {
 
   @JsonIgnore
   public Map<String, Object> getTopic() {
-    return (Map<String, Object>) kafka.getOrDefault("topic", Collections.emptyMap());
+    return (Map<String, Object>) kafka.getOrDefault(StaticConfig.TOPIC_KEY, Collections.emptyMap());
   }
 
   @JsonIgnore
   public Map<String, String> getConfig() {
-    return (Map<String, String>) getTopic().getOrDefault("config", Collections.emptyMap());
+    return (Map<String, String>)
+        getTopic().getOrDefault(StaticConfig.CONFIG_KEY, Collections.emptyMap());
   }
 }

--- a/platform-api/src/main/java/io/datacater/core/stream/StreamsUtilities.java
+++ b/platform-api/src/main/java/io/datacater/core/stream/StreamsUtilities.java
@@ -5,20 +5,68 @@ import io.datacater.core.authentication.DataCaterSessionFactory;
 import io.datacater.core.config.ConfigEntity;
 import io.datacater.core.config.ConfigUtilities;
 import io.datacater.core.exceptions.DatacaterException;
+import io.datacater.core.exceptions.DeleteStreamException;
+import io.datacater.core.utilities.LoggerUtilities;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.unchecked.Unchecked;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
 
 @ApplicationScoped
 public class StreamsUtilities {
+  private static final Logger LOGGER = Logger.getLogger(StreamsUtilities.class);
 
+  public static final Integer KAFKA_API_TIMEOUT_MS =
+      ConfigProvider.getConfig()
+          .getOptionalValue("kafka.api.timeout.ms", Integer.class)
+          .orElse(5000);
+
+  public static final String streamNotFoundMessage = "Stream not found.";
+  public static final String streamDeleteNotFinishedMessage =
+      "Stream deletion was called without errors but has not finished yet.";
   @Inject DataCaterSessionFactory dsf;
 
   public Uni<List<StreamMessage>> getStreamMessages(UUID uuid) {
     return getStreamMessages(uuid, 100L, SampleMethod.SEQUENCED);
+  }
+
+  public void updateStreamObject(Stream stream, List<ConfigEntity> configList)
+      throws JsonProcessingException {
+    Stream streamWithConfig = ConfigUtilities.applyConfigsToStream(Stream.from(stream), configList);
+    StreamService kafkaAdmin = KafkaStreamsAdmin.from(streamWithConfig);
+    kafkaAdmin.updateStream(streamWithConfig.spec());
+    kafkaAdmin.close();
+  }
+
+  public void deleteStreamObject(Stream stream, List<ConfigEntity> configList) {
+    stream = ConfigUtilities.applyConfigsToStream(stream, configList);
+    StreamService kafkaAdmin = KafkaStreamsAdmin.from(stream);
+    try {
+      kafkaAdmin.deleteStream().get(KAFKA_API_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    } catch (ExecutionException e) {
+      throw new DeleteStreamException(e.getMessage());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new DeleteStreamException(e.getMessage());
+    } catch (TimeoutException e) {
+      LoggerUtilities.logExceptionMessage(
+          LOGGER, new Throwable().getStackTrace()[0].getMethodName(), e.getMessage());
+      LOGGER.info(streamDeleteNotFinishedMessage);
+    }
+  }
+
+  public void createStreamObject(Stream stream, List<ConfigEntity> configList) {
+    stream = ConfigUtilities.applyConfigsToStream(stream, configList);
+    StreamService kafkaAdmin = KafkaStreamsAdmin.from(stream);
+    kafkaAdmin.createStream(stream.spec());
+    kafkaAdmin.close();
   }
 
   public Uni<List<StreamMessage>> getStreamMessages(

--- a/platform-api/src/main/java/io/datacater/core/utilities/LoggerUtilities.java
+++ b/platform-api/src/main/java/io/datacater/core/utilities/LoggerUtilities.java
@@ -1,0 +1,33 @@
+package io.datacater.core.utilities;
+
+import org.jboss.logging.Logger;
+
+public class LoggerUtilities {
+
+  /**
+   * Log an exception thrown with an added context
+   *
+   * @param logger The JBoss logger instance used for logging
+   * @param methodName The method name from which the exception occurred
+   * @param exceptionMessage The exception message to log
+   */
+  public static void logExceptionMessage(
+      Logger logger, String methodName, String exceptionMessage) {
+    logger.error(
+        "An error occurred while executing the '" + methodName + "' method: " + exceptionMessage);
+  }
+
+  /**
+   * Get the cause of an exception message. This method is used when an exception is encapsulated
+   * inside another exception to receive the original cause thrown.
+   *
+   * @param ex Exception to extract the cause from
+   * @return the cause of an exception if it exists, otherwise return the exception message.
+   */
+  public static String getExceptionCauseIfAvailable(Exception ex) {
+    if (ex.getCause() == null) {
+      return ex.getMessage();
+    }
+    return ex.getCause().getMessage();
+  }
+}


### PR DESCRIPTION
This PR refactors all the top level resources in datacater.

Refactors include:
- Moving all non-http methods from the endpoint classes to respective utility classes
  - pipeline resources in pipeline utility, stream resources in stream utility, etc.
- adding static config classes where not already existant
- removing "magic variables" to the static config classes
- refining some logging messages
- adding logging statements where I saw fit 
- added a logger utility class for generic logger methods


Please feel free to make more suggestions.