### PR TITLE
Remove obsolete CORS configuration to clean up deployment logs

### DIFF
--- a/pipeline/src/main/resources/application.yml
+++ b/pipeline/src/main/resources/application.yml
@@ -12,8 +12,6 @@ quarkus  :
     group: datacater
     name: ${quarkus.application.name}
     tag: ${quarkus.application.version}
-    http:
-      cors: true
 mp       :
   messaging:
     outgoing:


### PR DESCRIPTION
The deployment logs look much better nowadays and I had to clean up only one warning to fix #62.

This PR cleans up the deployment logs by removing the Quarkus configuration option `quarkus.container-image.http.cors` that is no longer available and would cause the following warning in the logs:

```
io.quarkus.config Unrecognized configuration key "quarkus.container-image.http.cors" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo
```

Fixes #62