### PR TITLE
fix(python-runner): Update requests to >= 2.31.0

### DIFF
--- a/python-runner/requirements.txt
+++ b/python-runner/requirements.txt
@@ -1,4 +1,4 @@
 fastapi >=0.80.0, < 0.81.0
 uvicorn[standard] >=0.18.2, < 0.19.0
 PyYAML  >=6.0, < 6.1
-requests >= 2.28.1, < 2.29.0
+requests >= 2.31.0, < 2.32.0


### PR DESCRIPTION
Dependabot [reported](https://github.com/DataCater/datacater/security/dependabot/15) an unintended leak of the `Proxy-Authorization` header in the version of the `requests` library that we are using (all versions < 2.31.0 are affected).

This commit updates the `python_runner/requirements.txt` and requires a version of `requests` where this issue has been fixed (>= 2.31.0).