### PR TITLE
feat(deployments/logs): Support defining tailingLines

### DIFF
--- a/platform-api/src/main/java/io/datacater/core/deployment/DeploymentEndpoint.java
+++ b/platform-api/src/main/java/io/datacater/core/deployment/DeploymentEndpoint.java
@@ -57,7 +57,9 @@ public class DeploymentEndpoint {
   @GET
   @Path("{uuid}/logs")
   public Uni<List<String>> getLogs(
-      @PathParam("uuid") UUID deploymentId, @DefaultValue("1") @QueryParam("replica") int replica) {
+      @PathParam("uuid") UUID deploymentId,
+      @DefaultValue("1") @QueryParam("replica") int replica,
+      @DefaultValue("100") @QueryParam("tailingLines") int tailingLines) {
     return dsf.withTransaction(
             ((session, transaction) -> session.find(DeploymentEntity.class, deploymentId)))
         .onItem()
@@ -68,7 +70,8 @@ public class DeploymentEndpoint {
         .transform(
             Unchecked.function(
                 deployment ->
-                    deploymentsUtil.getDeploymentLogsAsList(deployment.getId(), replica)));
+                    deploymentsUtil.getDeploymentLogsAsList(
+                        deployment.getId(), replica, tailingLines)));
   }
 
   @GET

--- a/platform-api/src/main/java/io/datacater/core/deployment/DeploymentUtilities.java
+++ b/platform-api/src/main/java/io/datacater/core/deployment/DeploymentUtilities.java
@@ -33,9 +33,9 @@ public class DeploymentUtilities {
 
   @Inject KubernetesClient client;
 
-  public List<String> getDeploymentLogsAsList(UUID deploymentId, int replica) {
+  public List<String> getDeploymentLogsAsList(UUID deploymentId, int replica, int tailingLines) {
     K8Deployment k8Deployment = new K8Deployment(client);
-    return Arrays.asList(k8Deployment.getLogs(deploymentId, replica).split("\n"));
+    return Arrays.asList(k8Deployment.getLogs(deploymentId, replica, tailingLines).split("\n"));
   }
 
   public HttpRequest buildDeploymentServiceRequest(UUID deploymentId, String path, int replica) {

--- a/platform-api/src/main/java/io/datacater/core/deployment/K8Deployment.java
+++ b/platform-api/src/main/java/io/datacater/core/deployment/K8Deployment.java
@@ -167,7 +167,7 @@ public class K8Deployment {
     return new ConfigMapVolumeSourceBuilder().withName(deploymentName).build();
   }
 
-  public String getLogs(UUID deploymentId, int replica) {
+  public String getLogs(UUID deploymentId, int replica, int tailingLines) {
 
     String deploymentName = getDeploymentName(deploymentId);
     Pod pod = getDeploymentPodByReplica(deploymentName, replica);
@@ -177,6 +177,7 @@ public class K8Deployment {
         .inNamespace(StaticConfig.EnvironmentVariables.NAMESPACE)
         .withName(pod.getMetadata().getName())
         .inContainer(StaticConfig.DEPLOYMENT_NAME_PREFIX + deploymentId)
+        .tailingLines(tailingLines)
         .getLog(true);
   }
 


### PR DESCRIPTION
Introduce the query parameter `tailingLines` to the `/deployments/:uuid/logs` endpoint, which is set to `100` by default and allows users to define the number of tailing log lines that shall be returned by the API endpoint.

⚠️  **Please note** that this commit slightly changes the default behavior of the endpoint, which did not limit the number of returned log lines in the past, potentially causing issues on both the client and server side.

Unfortunately, I could not test this change, as the mocked Kubernetes server does not return container logs. cc @ChrisRousey @HknLof Can you confirm this observation or are you able to prove me wrong? I would prefer the latter, so we could add tests :)

Fixes #46 