### PR TITLE
fix(ui/logs): Handle unparseable log messages

### DIFF
--- a/ui/src/containers/deployments/DeploymentLogs.js
+++ b/ui/src/containers/deployments/DeploymentLogs.js
@@ -182,12 +182,22 @@ class DeploymentLogs extends Component {
                       >
                         {this.state.logMessages.map((logMessage, idx) => (
                           <React.Fragment key={idx}>
-                            <span className="me-2" style={{ color: "#ae75e6" }}>
-                              {logMessage.timestamp}
-                            </span>
-                            <span className="me-2" style={{ color: "#b4d2ea" }}>
-                              {logMessage.loggerName}
-                            </span>
+                            {logMessage.timestamp !== undefined && (
+                              <span
+                                className="me-2"
+                                style={{ color: "#ae75e6" }}
+                              >
+                                {logMessage.timestamp}
+                              </span>
+                            )}
+                            {logMessage.loggerName !== undefined && (
+                              <span
+                                className="me-2"
+                                style={{ color: "#b4d2ea" }}
+                              >
+                                {logMessage.loggerName}
+                              </span>
+                            )}
                             {logMessage.message} <br />
                           </React.Fragment>
                         ))}

--- a/ui/src/reducers/deployments.js
+++ b/ui/src/reducers/deployments.js
@@ -97,7 +97,17 @@ const deployments = (state, action) => {
       };
     case "RECEIVE_LOGS_DEPLOYMENT":
       const logMessages = action.logMessages.slice(-101, -1).map((logLine) => {
-        return JSON.parse(logLine);
+        // By default, the API returns log messages in the JSON format
+        //
+        // In rare cases, Kubernetes mixes the JSON format with a pure text format.
+        // In such a case, we need to manually construct JSON objects, so we do not break the UI
+        try {
+          return JSON.parse(logLine);
+        } catch (error) {
+          return {
+            message: logLine,
+          };
+        }
       });
       return {
         ...state,


### PR DESCRIPTION
By default, the `/deployments/:uuid/logs` endpoint returns log messages of the given deployment in the JSON-NL format.

In rare cases, this endpoint mixes lines with pure text, i.e., invalid JSON, into the result, which breaks the UI.

Here is an example of such an API response (the first two lines cause the troubles):

```json
[
   "Starting the Java application using /opt/jboss/container/java/run/run-java.sh ...",
   "INFO exec  java -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+ExitOnOutOfMemoryError -cp \".\" -jar /deployments/quarkus-run.jar ",
   "{\"timestamp\":\"2023-05-26T06:59:07.497Z\",\"sequence\":71,\"loggerClassName\":\"org.jboss.logging.Logger\",\"loggerName\":\"io.quarkus.smallrye.openapi.runtime.OpenApiRecorder\",\"level\":\"INFO\",\"message\":\"CORS filtering is disabled and cross-origin resource sharing is allowed without restriction, which is not recommended in production. Please configure the CORS filter through 'quarkus.http.cors.*' properties. For more information, see Quarkus HTTP CORS documentation\",\"threadName\":\"main\",\"threadId\":1,\"mdc\":{},\"ndc\":\"\",\"hostName\":\"datacater-deployment-63f7eec6-381f-4251-a2c6-c9bb69796dac-tpnm8\",\"processName\":\"quarkus-run.jar\",\"processId\":1}",
   "{\"timestamp\":\"2023-05-26T06:59:07.563Z\",\"sequence\":72,\"loggerClassName\":\"io.smallrye.reactive.messaging.kafka.i18n.KafkaLogging_$logger\",\"loggerName\":\"io.smallrye.reactive.messaging.kafka\",\"level\":\"INFO\",\"message\":\"SRMSG18229: Configured topics for channel 'streamin': [mysql_source.data_sets.crunchbase]\",\"threadName\":\"main\",\"threadId\":1,\"mdc\":{},\"ndc\":\"\",\"hostName\":\"datacater-deployment-63f7eec6-381f-4251-a2c6-c9bb69796dac-tpnm8\",\"processName\":\"quarkus-run.jar\",\"processId\":1}",
   "{\"timestamp\":\"2023-05-26T06:59:07.817Z\",\"sequence\":73,\"loggerClassName\":\"io.smallrye.reactive.messaging.kafka.i18n.KafkaLogging_$logger\",\"loggerName\":\"io.smallrye.reactive.messaging.kafka\",\"level\":\"INFO\",\"message\":\"SRMSG18258: Kafka producer kafka-producer-streamout, connected to Kafka brokers 'redpanda-0.redpanda.default.svc.cluster.local.:9093', is configured to write records to 'processed_companies'\",\"threadName\":\"smallrye-kafka-producer-thread-0\",\"threadId\":20,\"mdc\":{},\"ndc\":\"\",\"hostName\":\"datacater-deployment-63f7eec6-381f-4251-a2c6-c9bb69796dac-tpnm8\",\"processName\":\"quarkus-run.jar\",\"processId\":1}",
   "{\"timestamp\":\"2023-05-26T06:59:07.913Z\",\"sequence\":74,\"loggerClassName\":\"io.smallrye.reactive.messaging.kafka.i18n.KafkaLogging_$logger\",\"loggerName\":\"io.smallrye.reactive.messaging.kafka\",\"level\":\"INFO\",\"message\":\"SRMSG18257: Kafka consumer kafka-consumer-streamin, connected to Kafka brokers 'redpanda-0.redpanda.default.svc.cluster.local.:9093', belongs to the '63f7eec6-381f-4251-a2c6-c9bb69796dac' consumer group and is configured to poll records from [mysql_source.data_sets.crunchbase]\",\"threadName\":\"smallrye-kafka-consumer-thread-0\",\"threadId\":18,\"mdc\":{},\"ndc\":\"\",\"hostName\":\"datacater-deployment-63f7eec6-381f-4251-a2c6-c9bb69796dac-tpnm8\",\"processName\":\"quarkus-run.jar\",\"processId\":1}",
   "{\"timestamp\":\"2023-05-26T06:59:08.237Z\",\"sequence\":75,\"loggerClassName\":\"org.jboss.logging.Logger\",\"loggerName\":\"io.quarkus\",\"level\":\"INFO\",\"message\":\"pipeline 1 on JVM (powered by Quarkus 2.16.6.Final) started in 1.539s. Listening on: http://0.0.0.0:8080\",\"threadName\":\"main\",\"threadId\":1,\"mdc\":{},\"ndc\":\"\",\"hostName\":\"datacater-deployment-63f7eec6-381f-4251-a2c6-c9bb69796dac-tpnm8\",\"processName\":\"quarkus-run.jar\",\"processId\":1}",
   "{\"timestamp\":\"2023-05-26T06:59:08.237Z\",\"sequence\":76,\"loggerClassName\":\"org.jboss.logging.Logger\",\"loggerName\":\"io.quarkus\",\"level\":\"INFO\",\"message\":\"Profile prod activated. \",\"threadName\":\"main\",\"threadId\":1,\"mdc\":{},\"ndc\":\"\",\"hostName\":\"datacater-deployment-63f7eec6-381f-4251-a2c6-c9bb69796dac-tpnm8\",\"processName\":\"quarkus-run.jar\",\"processId\":1}",
   "{\"timestamp\":\"2023-05-26T06:59:08.238Z\",\"sequence\":77,\"loggerClassName\":\"org.jboss.logging.Logger\",\"loggerName\":\"io.quarkus\",\"level\":\"INFO\",\"message\":\"Installed features: [cdi, config-yaml, confluent-registry-avro, kafka-client, micrometer, resteasy-reactive, resteasy-reactive-jackson, smallrye-context-propagation, smallrye-health, smallrye-openapi, smallrye-reactive-messaging, smallrye-reactive-messaging-kafka, vertx]\",\"threadName\":\"main\",\"threadId\":1,\"mdc\":{},\"ndc\":\"\",\"hostName\":\"datacater-deployment-63f7eec6-381f-4251-a2c6-c9bb69796dac-tpnm8\",\"processName\":\"quarkus-run.jar\",\"processId\":1}",
   "{\"timestamp\":\"2023-05-26T06:59:11.393Z\",\"sequence\":78,\"loggerClassName\":\"io.smallrye.reactive.messaging.kafka.i18n.KafkaLogging_$logger\",\"loggerName\":\"io.smallrye.reactive.messaging.kafka\",\"level\":\"INFO\",\"message\":\"SRMSG18256: Initialize record store for topic-partition 'mysql_source.data_sets.crunchbase-1' at position -1.\",\"threadName\":\"vert.x-eventloop-thread-1\",\"threadId\":25,\"mdc\":{},\"ndc\":\"\",\"hostName\":\"datacater-deployment-63f7eec6-381f-4251-a2c6-c9bb69796dac-tpnm8\",\"processName\":\"quarkus-run.jar\",\"processId\":1}",
   "{\"timestamp\":\"2023-05-26T06:59:11.398Z\",\"sequence\":79,\"loggerClassName\":\"io.smallrye.reactive.messaging.kafka.i18n.KafkaLogging_$logger\",\"loggerName\":\"io.smallrye.reactive.messaging.kafka\",\"level\":\"INFO\",\"message\":\"SRMSG18256: Initialize record store for topic-partition 'mysql_source.data_sets.crunchbase-0' at position -1.\",\"threadName\":\"vert.x-eventloop-thread-1\",\"threadId\":25,\"mdc\":{},\"ndc\":\"\",\"hostName\":\"datacater-deployment-63f7eec6-381f-4251-a2c6-c9bb69796dac-tpnm8\",\"processName\":\"quarkus-run.jar\",\"processId\":1}",
   "{\"timestamp\":\"2023-05-26T06:59:11.399Z\",\"sequence\":80,\"loggerClassName\":\"io.smallrye.reactive.messaging.kafka.i18n.KafkaLogging_$logger\",\"loggerName\":\"io.smallrye.reactive.messaging.kafka\",\"level\":\"INFO\",\"message\":\"SRMSG18256: Initialize record store for topic-partition 'mysql_source.data_sets.crunchbase-2' at position -1.\",\"threadName\":\"vert.x-eventloop-thread-1\",\"threadId\":25,\"mdc\":{},\"ndc\":\"\",\"hostName\":\"datacater-deployment-63f7eec6-381f-4251-a2c6-c9bb69796dac-tpnm8\",\"processName\":\"quarkus-run.jar\",\"processId\":1}",
   "{\"timestamp\":\"2023-05-26T06:59:31.299Z\",\"sequence\":81,\"loggerClassName\":\"org.jboss.logging.Logger\",\"loggerName\":\"io.datacater.Pipeline\",\"level\":\"ERROR\",\"message\":\"Pipeline could not process record: {\\\"key\\\":{\\\"schema\\\":{\\\"type\\\":\\\"struct\\\",\\\"fields\\\":[{\\\"type\\\":\\\"int32\\\",\\\"optional\\\":false,\\\"field\\\":\\\"id\\\"}],\\\"optional\\\":false,\\\"name\\\":\\\"mysql_source.data_sets.crunchbase.Key\\\"},\\\"payload\\\":{\\\"id\\\":10004}},\\\"value\\\":null,\\\"metadata\\\":{\\\"offset\\\":3350,\\\"partition\\\":1,\\\"error\\\":{\\\"location\\\":{\\\"path\\\":\\\"steps[0]\\\"},\\\"exceptionMessage\\\":\\\"TypeError: 'NoneType' object is not subscriptable\\\",\\\"exceptionName\\\":\\\"TypeError\\\",\\\"file\\\":{\\\"name\\\":null,\\\"lineNumber\\\":null},\\\"stacktrace\\\":[\\\"Traceback (most recent call last):\\\",\\\"  File \\\\\\\"/usr/app/runner.py\\\\\\\", line 109, in apply_pipeline\\\",\\\"    record = TRANSFORMS[record_transform[\\\\\\\"key\\\\\\\"]](\\\",\\\"             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\\",\\\"  File \\\\\\\"/usr/app/transforms/userdefinedrecordtransformation/transform.py\\\\\\\", line 7, in transform\\\",\\\"    return scope[\\\\\\\"transform\\\\\\\"](record)\\\",\\\"           ^^^^^^^^^^^^^^^^^^^^^^^^^^\\\",\\\"  File \\\\\\\"<string>\\\\\\\", line 6, in transform\\\",\\\"TypeError: 'NoneType' object is not subscriptable\\\",\\\"\\\"]}}}\",\"threadName\":\"executor-thread-0\",\"threadId\":15,\"mdc\":{},\"ndc\":\"\",\"hostName\":\"datacater-deployment-63f7eec6-381f-4251-a2c6-c9bb69796dac-tpnm8\",\"processName\":\"quarkus-run.jar\",\"processId\":1}",
   "{\"timestamp\":\"2023-05-26T06:59:31.3Z\",\"sequence\":82,\"loggerClassName\":\"org.jboss.logging.Logger\",\"loggerName\":\"io.datacater.Pipeline\",\"level\":\"ERROR\",\"message\":\"Pipeline could not process record: {\\\"key\\\":{\\\"schema\\\":{\\\"type\\\":\\\"struct\\\",\\\"fields\\\":[{\\\"type\\\":\\\"int32\\\",\\\"optional\\\":false,\\\"field\\\":\\\"id\\\"}],\\\"optional\\\":false,\\\"name\\\":\\\"mysql_source.data_sets.crunchbase.Key\\\"},\\\"payload\\\":{\\\"id\\\":10005}},\\\"value\\\":null,\\\"metadata\\\":{\\\"offset\\\":3353,\\\"partition\\\":1,\\\"error\\\":{\\\"location\\\":{\\\"path\\\":\\\"steps[0]\\\"},\\\"exceptionMessage\\\":\\\"TypeError: 'NoneType' object is not subscriptable\\\",\\\"exceptionName\\\":\\\"TypeError\\\",\\\"file\\\":{\\\"name\\\":null,\\\"lineNumber\\\":null},\\\"stacktrace\\\":[\\\"Traceback (most recent call last):\\\",\\\"  File \\\\\\\"/usr/app/runner.py\\\\\\\", line 109, in apply_pipeline\\\",\\\"    record = TRANSFORMS[record_transform[\\\\\\\"key\\\\\\\"]](\\\",\\\"             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\\",\\\"  File \\\\\\\"/usr/app/transforms/userdefinedrecordtransformation/transform.py\\\\\\\", line 7, in transform\\\",\\\"    return scope[\\\\\\\"transform\\\\\\\"](record)\\\",\\\"           ^^^^^^^^^^^^^^^^^^^^^^^^^^\\\",\\\"  File \\\\\\\"<string>\\\\\\\", line 6, in transform\\\",\\\"TypeError: 'NoneType' object is not subscriptable\\\",\\\"\\\"]}}}\",\"threadName\":\"executor-thread-0\",\"threadId\":15,\"mdc\":{},\"ndc\":\"\",\"hostName\":\"datacater-deployment-63f7eec6-381f-4251-a2c6-c9bb69796dac-tpnm8\",\"processName\":\"quarkus-run.jar\",\"processId\":1}",
   "{\"timestamp\":\"2023-05-26T06:59:31.302Z\",\"sequence\":83,\"loggerClassName\":\"org.jboss.logging.Logger\",\"loggerName\":\"io.datacater.Pipeline\",\"level\":\"ERROR\",\"message\":\"Pipeline could not process record: {\\\"key\\\":{\\\"schema\\\":{\\\"type\\\":\\\"struct\\\",\\\"fields\\\":[{\\\"type\\\":\\\"int32\\\",\\\"optional\\\":false,\\\"field\\\":\\\"id\\\"}],\\\"optional\\\":false,\\\"name\\\":\\\"mysql_source.data_sets.crunchbase.Key\\\"},\\\"payload\\\":{\\\"id\\\":10003}},\\\"value\\\":null,\\\"metadata\\\":{\\\"offset\\\":3322,\\\"partition\\\":2,\\\"error\\\":{\\\"location\\\":{\\\"path\\\":\\\"steps[0]\\\"},\\\"exceptionMessage\\\":\\\"TypeError: 'NoneType' object is not subscriptable\\\",\\\"exceptionName\\\":\\\"TypeError\\\",\\\"file\\\":{\\\"name\\\":null,\\\"lineNumber\\\":null},\\\"stacktrace\\\":[\\\"Traceback (most recent call last):\\\",\\\"  File \\\\\\\"/usr/app/runner.py\\\\\\\", line 109, in apply_pipeline\\\",\\\"    record = TRANSFORMS[record_transform[\\\\\\\"key\\\\\\\"]](\\\",\\\"             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\\",\\\"  File \\\\\\\"/usr/app/transforms/userdefinedrecordtransformation/transform.py\\\\\\\", line 7, in transform\\\",\\\"    return scope[\\\\\\\"transform\\\\\\\"](record)\\\",\\\"           ^^^^^^^^^^^^^^^^^^^^^^^^^^\\\",\\\"  File \\\\\\\"<string>\\\\\\\", line 6, in transform\\\",\\\"TypeError: 'NoneType' object is not subscriptable\\\",\\\"\\\"]}}}\",\"threadName\":\"executor-thread-0\",\"threadId\":15,\"mdc\":{},\"ndc\":\"\",\"hostName\":\"datacater-deployment-63f7eec6-381f-4251-a2c6-c9bb69796dac-tpnm8\",\"processName\":\"quarkus-run.jar\",\"processId\":1}"
]
```

This fix lets the UI cope with this rare behavior and manually constructs JSON objects from lines that cannot be parsed into JSON objects.