### PR TITLE
fix: fix injection bug introduced after refactoring pipelines

### DIFF
--- a/platform-api/src/main/java/io/datacater/core/pipeline/PipelineEndpoint.java
+++ b/platform-api/src/main/java/io/datacater/core/pipeline/PipelineEndpoint.java
@@ -6,6 +6,7 @@ import io.datacater.core.authentication.DataCaterSessionFactory;
 import io.datacater.core.exceptions.DatacaterException;
 import io.datacater.core.exceptions.PipelineNotFoundException;
 import io.datacater.core.kubernetes.DataCaterK8sConfig;
+import io.datacater.core.kubernetes.PythonRunnerPool;
 import io.datacater.core.kubernetes.PythonRunnerPool.NamedPod;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.quarkus.security.Authenticated;
@@ -41,6 +42,7 @@ import org.jboss.logging.Logger;
 @SecurityRequirement(name = "apiToken")
 public class PipelineEndpoint {
 
+  @Inject PythonRunnerPool runnerPool;
   static final Logger LOGGER = Logger.getLogger(PipelineEndpoint.class);
   @Inject PipelineUtilities pipelineUtil;
   @Inject KubernetesClient kubernetesClient;
@@ -111,7 +113,7 @@ public class PipelineEndpoint {
   public Uni<Response> preview(String payload) {
     LOGGER.debug(payload);
     HttpClient httpClient = HttpClient.newHttpClient();
-    Uni<NamedPod> namedPod = pipelineUtil.runnerPool.getPod();
+    Uni<NamedPod> namedPod = runnerPool.getPod();
 
     return namedPod
         .onItem()


### PR DESCRIPTION
After refactoring our pipelines resource, we were injecting the `PythonRunnerPool` inside the utilities class and trying to access it in the `PipelineEndpoint` through the injected `PipelineUtilities`.

This Fix removes this detour and injects the `PythonRunnerPool` directly in the `PipelineEndpoint` class.