### PR TITLE
feat(api/deployments): Forward health response status

### DIFF
--- a/platform-api/src/main/java/io/datacater/core/deployment/DeploymentEndpoint.java
+++ b/platform-api/src/main/java/io/datacater/core/deployment/DeploymentEndpoint.java
@@ -95,6 +95,12 @@ public class DeploymentEndpoint {
                           replica);
                   HttpResponse<String> response =
                       httpClient.send(req, HttpResponse.BodyHandlers.ofString());
+
+                  if (response.statusCode()
+                      >= Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()) {
+                    throw new UnhealthyDeploymentException(response.body());
+                  }
+
                   return Response.ok().entity(response.body()).build();
                 }));
   }

--- a/platform-api/src/main/java/io/datacater/core/exceptions/UnhealthyDeploymentException.java
+++ b/platform-api/src/main/java/io/datacater/core/exceptions/UnhealthyDeploymentException.java
@@ -1,0 +1,10 @@
+package io.datacater.core.exceptions;
+
+import io.datacater.core.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+public class UnhealthyDeploymentException extends RuntimeException {
+  public UnhealthyDeploymentException(String message) {
+    super(message);
+  }
+}

--- a/platform-api/src/main/java/io/datacater/core/exceptions/UnhealthyDeploymentExceptionMapper.java
+++ b/platform-api/src/main/java/io/datacater/core/exceptions/UnhealthyDeploymentExceptionMapper.java
@@ -1,0 +1,21 @@
+package io.datacater.core.exceptions;
+
+import io.datacater.core.ExcludeFromGeneratedCoverageReport;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@ExcludeFromGeneratedCoverageReport
+@Provider
+public class UnhealthyDeploymentExceptionMapper
+    implements ExceptionMapper<UnhealthyDeploymentException> {
+  @Override
+  public Response toResponse(UnhealthyDeploymentException exception) {
+    Error error =
+        Error.from(
+            Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+            Response.Status.INTERNAL_SERVER_ERROR,
+            exception.getMessage());
+    return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(error).build();
+  }
+}


### PR DESCRIPTION
The `/api/v1/deployments/{uuid}/health` endpoint returns the health status of the underlying Kubernetes Deployment.

So far, the endpoint returns the health information in the response body and always uses the HTTP status code 200 (OK) for the response. This is suboptimal and does not allow for a straightforward integration of the endpoint with observability and monitoring products, which often inspect the response status code (and not the response body) for evaluating whether a service is healthy.

This commit changes the behavior of the endpoint as follows:

* If the Kubernetes Deployment is healthy, it returns the HTTP status OK (200).
* If the Kubernetes Deployment is not healthy, it returns the HTTP status INTERNAL SERVER ERROR (500).